### PR TITLE
Handle compiler versions as integer tuples and verify compiler name

### DIFF
--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -121,8 +121,8 @@ def handle_compiler_args(config: BuildConfig, common_flags=None,
     if not isinstance(compiler, FortranCompiler):
         raise RuntimeError(f"Unexpected tool '{compiler.name}' of type "
                            f"'{type(compiler)}' instead of FortranCompiler")
-    version_string = '.'.join(str(x) for x in compiler.get_version())
-    logger.info(f'Fortran compiler is {compiler} {version_string}')
+    logger.info(
+        f'Fortran compiler is {compiler} {compiler.get_version_string()}')
 
     # Collate the flags from 1) flags env and 2) parameters.
     env_flags = os.getenv('FFLAGS', '').split()

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -121,7 +121,8 @@ def handle_compiler_args(config: BuildConfig, common_flags=None,
     if not isinstance(compiler, FortranCompiler):
         raise RuntimeError(f"Unexpected tool '{compiler.name}' of type "
                            f"'{type(compiler)}' instead of FortranCompiler")
-    logger.info(f'Fortran compiler is {compiler} {compiler.get_version()}')
+    version_string = '.'.join(str(x) for x in compiler.get_version())
+    logger.info(f'Fortran compiler is {compiler} {version_string}')
 
     # Collate the flags from 1) flags env and 2) parameters.
     env_flags = os.getenv('FFLAGS', '').split()

--- a/source/fab/tools/__init__.py
+++ b/source/fab/tools/__init__.py
@@ -10,8 +10,8 @@
 from fab.tools.ar import Ar
 from fab.tools.category import Category
 from fab.tools.compiler import (CCompiler, Compiler, FortranCompiler, Gcc,
-                                Gfortran, GnuCompiler, Icc, Ifort,
-                                IntelCompiler)
+                                Gfortran, GnuVersionHandling, Icc, Ifort,
+                                IntelVersionHandling)
 from fab.tools.flags import Flags
 from fab.tools.linker import Linker
 from fab.tools.psyclone import Psyclone
@@ -37,10 +37,10 @@ __all__ = ["Ar",
            "Gcc",
            "Gfortran",
            "Git",
-           "GnuCompiler",
+           "GnuVersionHandling",
            "Icc",
            "Ifort",
-           "IntelCompiler",
+           "IntelVersionHandling",
            "Linker",
            "Preprocessor",
            "Psyclone",

--- a/source/fab/tools/__init__.py
+++ b/source/fab/tools/__init__.py
@@ -10,7 +10,8 @@
 from fab.tools.ar import Ar
 from fab.tools.category import Category
 from fab.tools.compiler import (CCompiler, Compiler, FortranCompiler, Gcc,
-                                Gfortran, Icc, Ifort)
+                                Gfortran, GnuCompiler, Icc, Ifort,
+                                IntelCompiler)
 from fab.tools.flags import Flags
 from fab.tools.linker import Linker
 from fab.tools.psyclone import Psyclone
@@ -36,8 +37,10 @@ __all__ = ["Ar",
            "Gcc",
            "Gfortran",
            "Git",
+           "GnuCompiler",
            "Icc",
            "Ifort",
+           "IntelCompiler",
            "Linker",
            "Preprocessor",
            "Psyclone",

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -142,6 +142,20 @@ class Compiler(CompilerSuiteTool):
         self._version = version
         return version
 
+    def _run_version_command(self) -> str:
+        '''
+        Run the compiler's command to get its version.
+        Implemented in subclasses for specific compilers.
+        '''
+        raise NotImplementedError
+
+    def _parse_version_output(self, version_output) -> str:
+        '''
+        Extract the numerical part from the version output.
+        Implemented in subclasses for specific compilers.
+        '''
+        raise NotImplementedError
+
     def get_version_string(self) -> str:
         """
         Get a string representing the version of the given compiler.
@@ -271,7 +285,7 @@ class GnuCompiler(Compiler):
 
     def _parse_version_output(self, version_output) -> str:
         '''
-        Get the numerical part of the version output
+        Extract the numerical part from the version output
 
         :param version_output: the full version output from the compiler
         :returns: the actual version as a string
@@ -342,7 +356,7 @@ class IntelCompiler(Compiler):
 
     def _parse_version_output(self, version_output) -> str:
         '''
-        Get the numerical part of the version output
+        Extract the numerical part from the version output
 
         :param version_output: the full version output from the compiler
         :returns: the actual version as a string

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -118,7 +118,7 @@ class Compiler(CompilerSuiteTool):
 
         :raises RuntimeError: if the compiler was not found.
         """
-        if self._version != None:
+        if self._version is not None:
             return self._version
 
         try:
@@ -164,6 +164,7 @@ class Compiler(CompilerSuiteTool):
         self.logger.info(f'Found compiler version for {self.name} = {version_string}')
         self._version = version
         return version
+
 
 # ============================================================================
 class CCompiler(Compiler):

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -11,7 +11,7 @@ classes for gcc, gfortran, icc, ifort
 import os
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, Protocol
 import zlib
 
 from fab.tools.category import Category
@@ -162,7 +162,7 @@ class Compiler(CompilerSuiteTool):
     def _parse_version_output(self, version_output: str) -> str:
         '''
         Extract the numerical part from the version output.
-        Implemented in subclasses for specific compilers.
+        Implemented in mixins for specific compilers.
         '''
         raise NotImplementedError
 
@@ -178,6 +178,18 @@ class Compiler(CompilerSuiteTool):
         """
         version = self.get_version()
         return '.'.join(str(x) for x in version)
+
+
+class VersionHandler(Protocol):
+    ''' Protocol that defines common functionality required for parsing version
+    output.
+
+    Used by version handler mixins to avoid inheriting Compiler directly.
+    '''
+    @property
+    def name(self) -> str: ...
+    @property
+    def category(self) -> Category: ...
 
 
 # ============================================================================
@@ -275,10 +287,11 @@ class FortranCompiler(Compiler):
 
 
 # ============================================================================
-class GnuVersionHandling(Compiler):
+class GnuVersionHandling():
     '''Mixin to handle version information from GNU compilers'''
 
-    def _parse_version_output(self, version_output: str) -> str:
+    def _parse_version_output(
+            self: VersionHandler, version_output: str) -> str:
         '''
         Extract the numerical part from the version output
 
@@ -332,10 +345,11 @@ class Gfortran(GnuVersionHandling, FortranCompiler):
 
 
 # ============================================================================
-class IntelVersionHandling(Compiler):
+class IntelVersionHandling():
     '''Mixin to handle version information from Intel compilers'''
 
-    def _parse_version_output(self, version_output: str) -> str:
+    def _parse_version_output(
+            self: VersionHandler, version_output: str) -> str:
         '''
         Extract the numerical part from the version output
 

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -46,7 +46,7 @@ class Compiler(CompilerSuiteTool):
                  output_flag: Optional[str] = None,
                  omp_flag: Optional[str] = None):
         super().__init__(name, exec_name, suite, category)
-        self._version: Tuple[int, ...] | None = None
+        self._version: Union[Tuple[int, ...], None] = None
         self._compile_flag = compile_flag if compile_flag else "-c"
         self._output_flag = output_flag if output_flag else "-o"
         self._omp_flag = omp_flag

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -129,7 +129,7 @@ class Compiler(CompilerSuiteTool):
             raise RuntimeError(f"Error asking for version of compiler "
                                f"'{self.name}': {err}")
 
-        if not self.version_token in res:
+        if self.version_token not in res:
             raise RuntimeError(f"Unexpected version for {self.name} compiler. "
                                f"Should contain '{self.version_token}': "
                                f"{res}")

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -159,7 +159,7 @@ class Compiler(CompilerSuiteTool):
             raise RuntimeError(f"Error asking for version of compiler "
                                f"'{self.name}'") from err
 
-    def _parse_version_output(self, version_output) -> str:
+    def _parse_version_output(self, version_output: str) -> str:
         '''
         Extract the numerical part from the version output.
         Implemented in subclasses for specific compilers.

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -98,14 +98,16 @@ class Compiler(CompilerSuiteTool):
             # Compiler does not exist:
             return False
 
-        # An empty string is returned if some other error occurred when trying
+        # An empty tuple is returned if some other error occurred when trying
         # to get the compiler version.
-        return version != ""
+        return version != ()
 
     def get_version(self):
         """
         Try to get the version of the given compiler.
-        # TODO: why return empty set when an error happened?
+
+        # TODO: an empty tuple is returned for an invalid version, so that the
+        #       compiler can still be hashed. Is that necessary?
 
         Expects a version in a certain part of the --version output,
         which must adhere to the n.n.n format, with at least 2 parts.
@@ -116,7 +118,7 @@ class Compiler(CompilerSuiteTool):
 
         :raises RuntimeError: if the compiler was not found.
         """
-        if self._version:
+        if self._version != None:
             return self._version
 
         try:

--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -143,7 +143,7 @@ class Compiler(CompilerSuiteTool):
         # expect major.minor[.patch, ...]
         split = version_string.split('.')
         if len(split) < 2:
-            self.logger.warning(f"unhandled compiler version format for "
+            self.logger.warning(f"Unhandled compiler version format for "
                                 f"compiler '{self.name}' is not "
                                 f"<n.n[.n, ...]>: {version_string}")
             return ()
@@ -153,13 +153,10 @@ class Compiler(CompilerSuiteTool):
         try:
             version = tuple(int(x) for x in split)
         except ValueError:
-            self.logger.warning(f"unhandled compiler version format for "
-                                f"compiler '{self.name}' is not "
+            self.logger.warning(f"Unhandled compiler version for compiler "
+                                f"'{self.name}' should be numeric "
                                 f"<n.n[.n, ...]>: {version_string}")
             return ()
-
-        # How to convert back to string:
-        version_string = '.'.join(str(x) for x in version)
 
         self.logger.info(f'Found compiler version for {self.name} = {version_string}')
         self._version = version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def fixture_mock_c_compiler():
     '''Provides a mock C-compiler.'''
     mock_compiler = CCompiler("mock_c_compiler", "mock_exec", "suite")
     mock_compiler.run = mock.Mock()
-    mock_compiler._version = "1.2.3"
+    mock_compiler._version = (1, 2, 3)
     mock_compiler._name = "mock_c_compiler"
     mock_compiler._exec_name = "mock_c_compiler.exe"
     return mock_compiler
@@ -36,7 +36,7 @@ def fixture_mock_fortran_compiler():
     mock_compiler.run = mock.Mock()
     mock_compiler._name = "mock_fortran_compiler"
     mock_compiler._exec_name = "mock_fortran_compiler.exe"
-    mock_compiler._version = "1.2.3"
+    mock_compiler._version = (1, 2, 3)
     return mock_compiler
 
 
@@ -46,7 +46,7 @@ def fixture_mock_linker():
     mock_linker = Linker("mock_linker", "mock_linker.exe",
                          Category.FORTRAN_COMPILER)
     mock_linker.run = mock.Mock()
-    mock_linker._version = "1.2.3"
+    mock_linker._version = (1, 2, 3)
     return mock_linker
 
 

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -156,6 +156,6 @@ class TestGetObjComboHash:
         changes the hash.'''
         config, analysed_file, expect_hash = content
         compiler = config.tool_box[Category.C_COMPILER]
-        compiler._version = "9.8.7"
+        compiler._version = (9, 8, 7)
         result = _get_obj_combo_hash(compiler, analysed_file, flags)
         assert result != expect_hash

--- a/tests/unit_tests/steps/test_compile_fortran.py
+++ b/tests/unit_tests/steps/test_compile_fortran.py
@@ -376,7 +376,7 @@ class TestProcessFile:
         # changing the compiler version must change the combo hash for the mods and obj
         mp_common_args, flags, analysed_file, orig_obj_hash, orig_mods_hash = content
         compiler = mp_common_args.config.tool_box[Category.FORTRAN_COMPILER]
-        compiler._version = "9.8.7"
+        compiler._version = (9, 8, 7)
 
         obj_combo_hash = '1a87f4e07'
         mods_combo_hash = '131edbafd'

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -35,7 +35,7 @@ def test_compiler():
     assert fc.flags == []
 
 
-def test_available():
+def test_compiler_check_available():
     '''Check if check_available works as expected. The compiler class uses
     internally get_version to test if a compiler works or not. Check the
     compiler is available when it has a valid version.
@@ -45,7 +45,7 @@ def test_available():
         assert cc.check_available()
 
 
-def test_not_available_after_error():
+def test_compiler_check_available_runtime_error():
     ''' Check the compiler is not available when get_version raises an error.
     '''
     cc = Gcc()
@@ -79,7 +79,7 @@ def test_compiler_hash_compiler_error():
     with mock.patch.object(cc, 'run', side_effect=RuntimeError()):
         with pytest.raises(RuntimeError) as err:
             cc.get_hash()
-            assert "Error asking for version of compiler" in str(err.value)
+        assert "Error asking for version of compiler" in str(err.value)
 
 
 def test_compiler_hash_invalid_version():
@@ -90,7 +90,7 @@ def test_compiler_hash_invalid_version():
     with mock.patch.object(cc, "run", mock.Mock(return_value='foo v1')):
         with pytest.raises(RuntimeError) as err:
             cc.get_hash()
-            assert "Unexpected version output format for compiler 'gcc'" in str(err.value)
+        assert "Unexpected version output format for compiler 'gcc'" in str(err.value)
 
 
 def test_compiler_with_env_fflags():

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -468,6 +468,7 @@ def test_ifort_get_version_14():
                            mock.Mock(return_value=full_version_string)):
         assert ifort.get_version() == (14, 0, 3)
 
+
 def test_ifort_get_version_15():
     '''Test ifort 15.0.2 version detection.'''
     full_version_string = dedent("""
@@ -480,6 +481,7 @@ def test_ifort_get_version_15():
                            mock.Mock(return_value=full_version_string)):
         assert ifort.get_version() == (15, 0, 2)
 
+
 def test_ifort_get_version_17():
     '''Test ifort 17.0.7 version detection.'''
     full_version_string = dedent("""
@@ -491,6 +493,7 @@ def test_ifort_get_version_17():
     with mock.patch.object(ifort, "run",
                            mock.Mock(return_value=full_version_string)):
         assert ifort.get_version() == (17, 0, 7)
+
 
 def test_ifort_get_version_19():
     '''Test ifort 19.0.0.117 version detection.'''

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -8,14 +8,15 @@
 '''
 
 import os
+import re
 from pathlib import Path, PosixPath
 from textwrap import dedent
 from unittest import mock
 
 import pytest
 
-from fab.tools import (Category, CCompiler, Compiler, FortranCompiler,
-                       Gcc, Gfortran, Icc, Ifort)
+from fab.tools import (Category, CCompiler, Compiler, FortranCompiler, Gcc,
+                       Gfortran, Icc, Ifort)
 
 
 def test_compiler():
@@ -35,27 +36,53 @@ def test_compiler():
     assert fc.flags == []
 
 
+# ============================================================================
+class FooCompiler(Compiler):
+    '''Minimal compiler implementation to test version handling.
+
+    :param version_output: mock output from the compiler's version command.
+    '''
+
+    def __init__(self, version_output=None):
+        super().__init__("Foo Fortran", "footran", "foo", Category.FORTRAN_COMPILER)
+        self._version_output = version_output
+
+    def _run_version_command(self):
+        return self._version_output
+
+    def _parse_version_output(self, output) -> str:
+        # Pull the version string from the command output.
+        # Just look for something numeric after parentheses.
+        matches = re.findall("\\) ([0-9\\.]+\\b)", output)
+
+        if not matches:
+            raise RuntimeError(f"Unexpected version output format for compiler "
+                               f"'{self.name}': {output}")
+
+        return matches[0]
+
+
 def test_available():
     '''Check if check_available works as expected. The compiler class uses
     internally get_version to test if a compiler works or not. Check the
     compiler is available when it has a valid version.
     '''
-    cc = CCompiler("gcc", "gcc", "gnu")
+    cc = Gcc()
     with mock.patch.object(cc, "get_version", returncode=(1, 2, 3)):
         assert cc.check_available()
 
 
-def test_available_after_error():
+def test_not_available_after_error():
     ''' Check the compiler is not available when get_version raises an error.
     '''
-    cc = CCompiler("gcc", "gcc", "gnu")
+    cc = Gcc()
     with mock.patch.object(cc, "get_version", side_effect=RuntimeError("")):
         assert not cc.check_available()
 
 
 def test_compiler_hash():
     '''Test the hash functionality.'''
-    cc = CCompiler("gcc", "gcc", "gnu")
+    cc = Gcc()
     with mock.patch.object(cc, "_version", (5, 6, 7)):
         hash1 = cc.get_hash()
         assert hash1 == 2768517656
@@ -73,7 +100,7 @@ def test_compiler_hash():
 
 def test_compiler_hash_compiler_error():
     '''Test the hash functionality when version info is missing.'''
-    cc = CCompiler("gcc", "gcc", "gnu")
+    cc = Gcc()
 
     # raise an error when trying to get compiler version
     with mock.patch.object(cc, 'run', side_effect=RuntimeError()):
@@ -84,20 +111,20 @@ def test_compiler_hash_compiler_error():
 
 def test_compiler_hash_invalid_version():
     '''Test the hash functionality when version info is missing.'''
-    cc = CCompiler("gcc", "gcc", "gnu")
+    cc = Gcc()
 
     # returns an invalid compiler version string
     with mock.patch.object(cc, "run", mock.Mock(return_value='foo v1')):
         with pytest.raises(RuntimeError) as err:
             cc.get_hash()
-            assert "Unexpected version response from compiler 'gcc'" in str(err.value)
+            assert "Unexpected version output format for compiler 'gcc'" in str(err.value)
 
 
 def test_compiler_with_env_fflags():
     '''Test that content of FFLAGS is added to the compiler flags.'''
     with mock.patch.dict(os.environ, FFLAGS='--foo --bar'):
-        cc = CCompiler("gcc", "gcc", "gnu")
-        fc = FortranCompiler("gfortran", "gfortran", "gnu", "-J")
+        cc = Gcc()
+        fc = Gfortran()
     assert cc.flags == ["--foo", "--bar"]
     assert fc.flags == ["--foo", "--bar"]
 
@@ -153,136 +180,126 @@ def test_compiler_with_add_args():
                                                      'a.f90', '-o', 'a.o'])
 
 
-class TestGetCompilerVersion:
-    '''Test `get_version`.'''
+def test_get_version_result_is_cached():
+    '''Checks that the compiler is only run once to extract the version.
+    '''
+    c = FooCompiler("Foo Fortran (Foo) 6.1.0")
+    expected = (6, 1, 0)
+    assert c.get_version() == expected
 
-    def _check_error(self, full_version_string: str, expected_error: str):
-        '''Checks if the correct error is raised from the given invalid
-        full_version_string.
-        '''
-        c = Compiler("Foo Fortran", "footran", "gnu", Category.FORTRAN_COMPILER)
-        with mock.patch.object(c, "run",
-                               mock.Mock(return_value=full_version_string)):
-            with pytest.raises(RuntimeError) as err:
-                c.get_version()
-            assert expected_error in str(err.value)
+    # Now let the run method raise an exception, to make sure we get a cached
+    # value back (and the run method isn't called again):
+    c.run = mock.Mock(side_effect=RuntimeError(""))
+    assert c.get_version() == expected
+    assert not c.run.called
 
-    def _check(self, full_version_string: str, expected: str):
-        '''Checks if the correct version is extracted from the given
-        full_version_string.
-        '''
-        c = Compiler("Foo Fortran", "footran", "gnu", Category.FORTRAN_COMPILER)
-        with mock.patch.object(c, "run",
-                               mock.Mock(return_value=full_version_string)):
-            assert c.get_version() == expected
-        # Now let the run method raise an exception, to make sure
-        # we get a cached value back (and the run method isn't called again):
-        with mock.patch.object(c, "run",
-                               mock.Mock(side_effect=RuntimeError(""))):
-            assert c.get_version() == expected
 
-    def test_command_failure(self):
-        '''If the version command fails, we must raise an error.'''
-        c = Compiler("Foo Fortran", "footran", "gnu",
-                     Category.FORTRAN_COMPILER)
-        with mock.patch.object(c, 'run', side_effect=RuntimeError()):
-            with pytest.raises(RuntimeError) as err:
-                c.get_version()
-            assert "Error asking for version of compiler" in str(err.value)
+def test_get_version_command_failure():
+    '''If the version command fails, we must raise an error.'''
+    c = Gfortran()
+    with mock.patch.object(c, 'run',
+                           side_effect=RuntimeError()):
+        with pytest.raises(RuntimeError) as err:
+            c.get_version()
+        assert "Error asking for version of compiler" in str(err.value)
 
-    def test_file_not_found(self):
-        '''If the compiler is not found, we must raise an error.'''
-        c = Compiler("Foo Fortran", "footran", "gnu",
-                     Category.FORTRAN_COMPILER)
-        with mock.patch.object(c, 'run', side_effect=FileNotFoundError()):
-            with pytest.raises(RuntimeError) as err:
-                c.get_version()
-            assert "Compiler not found: Foo Fortran" in str(err.value)
 
-    def test_unknown_command_response(self):
-        '''If the full version output is in an unknown format,
-        we must raise an error.'''
-        full_version_string = 'Foo Fortran 1.2.3'
-        expected_error = "Unexpected version response from compiler 'Foo Fortran'"
-        self._check_error(
-            full_version_string=full_version_string,
-            expected_error=expected_error
-        )
+def test_get_version_file_not_found():
+    '''If the compiler is not found, we must raise an error.'''
+    c = Gfortran()
+    with mock.patch.object(c, 'run',
+                           side_effect=FileNotFoundError()):
+        with pytest.raises(RuntimeError) as err:
+            c.get_version()
+        assert "Compiler not found" in str(err.value)
 
-    def test_unknown_version_format(self):
-        '''If the version is in an unknown format, we must raise an error.'''
 
-        full_version_string = dedent("""
-            Foo Fortran (Foo) 5 123456 (Foo Hat 4.8.5-44)
-            Copyright (C) 2022 Foo Software Foundation, Inc.
-        """)
-        expected_error = "Unexpected compiler version format for compiler 'Foo Fortran'"
-        self._check_error(
-            full_version_string=full_version_string,
-            expected_error=expected_error
-        )
+def test_get_version_unknown_command_response():
+    '''If the full version output is in an unknown format,
+    we must raise an error.'''
+    full_version_output = 'Foo Fortran 1.2.3'
+    expected_error = "Unexpected version output format for compiler 'Foo Fortran'"
 
-    def test_non_int_version_format(self):
-        '''If the version contains non-number characters, we must raise an error.'''
-        full_version_string = dedent("""
-            Foo Fortran (Foo) 5.1f.2g (Foo Hat 4.8.5)
-            Copyright (C) 2022 Foo Software Foundation, Inc.
-        """)
-        expected_error = "Unexpected compiler version format for compiler 'Foo Fortran'"
-        self._check_error(
-            full_version_string=full_version_string,
-            expected_error=expected_error
-        )
+    c = FooCompiler(full_version_output)
+    with pytest.raises(RuntimeError) as err:
+        c.get_version()
+    assert expected_error in str(err.value)
 
-    def test_1_part_version(self):
-        '''If the version is just one integer, that is invalid and we must
-        raise an error. '''
-        full_version_string = dedent("""
-            Foo Fortran (Foo) 77
-            Copyright (C) 2022 Foo Software Foundation, Inc.
-        """)
-        expected_error = "Unexpected compiler version format for compiler 'Foo Fortran'"
-        self._check_error(
-            full_version_string=full_version_string,
-            expected_error=expected_error
-        )
 
-    def test_2_part_version(self):
-        '''Test major.minor format. '''
-        full_version_string = dedent("""
-            Foo Fortran (Foo) 5.6 123456 (Foo Hat 1.2.3-45)
-            Copyright (C) 2022 Foo Software Foundation, Inc.
-        """)
-        self._check(full_version_string=full_version_string, expected=(5, 6))
+def test_get_version_unknown_version_format():
+    '''If the version is in an unknown format, we must raise an error.'''
 
-    def test_3_part_version(self):
-        '''Test major.minor.patch format. '''
-        full_version_string = dedent("""
-            Foo Fortran (Foo) 6.1.0
-        """)
-        self._check(full_version_string=full_version_string, expected=(6, 1, 0))
+    full_version_output = dedent("""
+        Foo Fortran (Foo) 5 123456 (Foo Hat 4.8.5-44)
+        Copyright (C) 2022 Foo Software Foundation, Inc.
+    """)
+    expected_error = "Unexpected version output format for compiler 'Foo Fortran'"
+    c = FooCompiler(full_version_output)
 
-    def test_4_part_version(self):
-        '''Test major.minor.patch.revision format. '''
-        full_version_string = dedent("""
-            Foo Fortran (Foo) 19.0.0.117 20180804
-        """)
-        self._check(
-            full_version_string=full_version_string,
-            expected=(19, 0, 0, 117)
-        )
+    with pytest.raises(RuntimeError) as err:
+        c.get_version()
+    assert expected_error in str(err.value)
+
+
+def test_get_version_non_int_version_format():
+    '''If the version contains non-number characters, we must raise an error.'''
+    full_version_output = dedent("""
+        Foo Fortran (Foo) 5.1f.2g (Foo Hat 4.8.5)
+        Copyright (C) 2022 Foo Software Foundation, Inc.
+    """)
+    expected_error = "Unexpected version output format for compiler 'Foo Fortran'"
+
+    c = FooCompiler(full_version_output)
+    with pytest.raises(RuntimeError) as err:
+        c.get_version()
+    assert expected_error in str(err.value)
+
+
+def test_get_version_1_part_version():
+    '''If the version is just one integer, that is invalid and we must
+    raise an error. '''
+    full_version_output = dedent("""
+        Foo Fortran (Foo) 77
+        Copyright (C) 2022 Foo Software Foundation, Inc.
+    """)
+    expected_error = "Unexpected version output format for compiler 'Foo Fortran'"
+
+    c = FooCompiler(full_version_output)
+    with pytest.raises(RuntimeError) as err:
+        c.get_version()
+    assert expected_error in str(err.value)
+
+
+def test_get_version_2_part_version():
+    '''Test major.minor format.
+    '''
+    full_version_output = dedent("""
+        Foo Fortran (Foo) 5.6 123456 (Foo Hat 1.2.3-45)
+        Copyright (C) 2022 Foo Software Foundation, Inc.
+    """)
+    c = FooCompiler(full_version_output)
+    assert c.get_version() == (5, 6)
+
+
+def test_get_version_3_part_version():
+    '''Test major.minor.patch format.
+    '''
+    c = FooCompiler('Foo Fortran (Foo) 6.1.0')
+    assert c.get_version() == (6, 1, 0)
+
+
+def test_get_version_4_part_version():
+    '''Test major.minor.patch.revision format.
+    '''
+    c = FooCompiler('Foo Fortran (Foo) 19.0.0.117 20180804')
+    assert c.get_version() == (19, 0, 0, 117)
 
 
 def test_get_version_string():
     '''Tests the compiler get_version_string() method.
     '''
-    full_version_string = dedent("""
-        Foo Fortran (Foo) 6.1.0
-    """)
-    c = Compiler("Foo Fortran", "footran", "gnu", Category.FORTRAN_COMPILER)
-    with mock.patch.object(c, "run",
-                           mock.Mock(return_value=full_version_string)):
-        assert c.get_version_string() == "6.1.0"
+    c = FooCompiler(version_output='Foo Fortran (Foo) 6.1.0')
+    assert c.get_version_string() == "6.1.0"
 
 
 # ============================================================================
@@ -297,28 +314,28 @@ def test_gcc():
 def test_gcc_get_version():
     '''Tests the gcc class get_version method.'''
     gcc = Gcc()
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20)
         Copyright (C) 2018 Free Software Foundation, Inc.
     """)
     with mock.patch.object(gcc, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert gcc.get_version() == (8, 5, 0)
 
 
 def test_gcc_get_version_with_icc_string():
     '''Tests the gcc class with an icc version output.'''
     gcc = Gcc()
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         icc (ICC) 2021.10.0 20230609
         Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.
 
     """)
     with mock.patch.object(gcc, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         with pytest.raises(RuntimeError) as err:
             gcc.get_version()
-        assert "Unexpected version for gcc compiler" in str(err.value)
+        assert "Unexpected version output format for compiler" in str(err.value)
 
 
 # ============================================================================
@@ -337,7 +354,7 @@ def test_gfortran():
 
 def test_gfortran_get_version_4():
     '''Test gfortran 4.8.5 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         GNU Fortran (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
         Copyright (C) 2015 Free Software Foundation, Inc.
 
@@ -349,13 +366,13 @@ def test_gfortran_get_version_4():
     """)
     gfortran = Gfortran()
     with mock.patch.object(gfortran, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert gfortran.get_version() == (4, 8, 5)
 
 
 def test_gfortran_get_version_6():
     '''Test gfortran 6.1.0 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         GNU Fortran (GCC) 6.1.0
         Copyright (C) 2016 Free Software Foundation, Inc.
         This is free software; see the source for copying conditions.  There is NO
@@ -364,13 +381,13 @@ def test_gfortran_get_version_6():
     """)
     gfortran = Gfortran()
     with mock.patch.object(gfortran, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert gfortran.get_version() == (6, 1, 0)
 
 
 def test_gfortran_get_version_8():
     '''Test gfortran 8.5.0 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         GNU Fortran (conda-forge gcc 8.5.0-16) 8.5.0
         Copyright (C) 2018 Free Software Foundation, Inc.
         This is free software; see the source for copying conditions.  There is NO
@@ -379,13 +396,13 @@ def test_gfortran_get_version_8():
     """)
     gfortran = Gfortran()
     with mock.patch.object(gfortran, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert gfortran.get_version() == (8, 5, 0)
 
 
 def test_gfortran_get_version_10():
     '''Test gfortran 10.4.0 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         GNU Fortran (conda-forge gcc 10.4.0-16) 10.4.0
         Copyright (C) 2020 Free Software Foundation, Inc.
         This is free software; see the source for copying conditions.  There is NO
@@ -394,13 +411,13 @@ def test_gfortran_get_version_10():
     """)
     gfortran = Gfortran()
     with mock.patch.object(gfortran, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert gfortran.get_version() == (10, 4, 0)
 
 
 def test_gfortran_get_version_12():
     '''Test gfortran 12.1.0 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         GNU Fortran (conda-forge gcc 12.1.0-16) 12.1.0
         Copyright (C) 2022 Free Software Foundation, Inc.
         This is free software; see the source for copying conditions.  There is NO
@@ -409,23 +426,23 @@ def test_gfortran_get_version_12():
     """)
     gfortran = Gfortran()
     with mock.patch.object(gfortran, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert gfortran.get_version() == (12, 1, 0)
 
 
 def test_gfortran_get_version_with_ifort_string():
     '''Tests the gfortran class with an ifort version output.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         ifort (IFORT) 14.0.3 20140422
         Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.
 
     """)
     gfortran = Gfortran()
     with mock.patch.object(gfortran, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         with pytest.raises(RuntimeError) as err:
             gfortran.get_version()
-        assert "Unexpected version for gfortran compiler" in str(err.value)
+        assert "Unexpected version output format for compiler" in str(err.value)
 
 
 # ============================================================================
@@ -439,29 +456,29 @@ def test_icc():
 
 def test_icc_get_version():
     '''Tests the icc class get_version method.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         icc (ICC) 2021.10.0 20230609
         Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.
 
     """)
     icc = Icc()
     with mock.patch.object(icc, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert icc.get_version() == (2021, 10, 0)
 
 
 def test_icc_get_version_with_gcc_string():
     '''Tests the icc class with a GCC version output.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20)
         Copyright (C) 2018 Free Software Foundation, Inc.
     """)
     icc = Icc()
     with mock.patch.object(icc, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         with pytest.raises(RuntimeError) as err:
             icc.get_version()
-        assert "Unexpected version for icc compiler" in str(err.value)
+        assert "Unexpected version output format for compiler" in str(err.value)
 
 
 # ============================================================================
@@ -475,69 +492,69 @@ def test_ifort():
 
 def test_ifort_get_version_14():
     '''Test ifort 14.0.3 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         ifort (IFORT) 14.0.3 20140422
         Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.
 
     """)
     ifort = Ifort()
     with mock.patch.object(ifort, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert ifort.get_version() == (14, 0, 3)
 
 
 def test_ifort_get_version_15():
     '''Test ifort 15.0.2 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         ifort (IFORT) 15.0.2 20150121
         Copyright (C) 1985-2015 Intel Corporation.  All rights reserved.
 
     """)
     ifort = Ifort()
     with mock.patch.object(ifort, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert ifort.get_version() == (15, 0, 2)
 
 
 def test_ifort_get_version_17():
     '''Test ifort 17.0.7 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         ifort (IFORT) 17.0.7 20180403
         Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
 
     """)
     ifort = Ifort()
     with mock.patch.object(ifort, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert ifort.get_version() == (17, 0, 7)
 
 
 def test_ifort_get_version_19():
     '''Test ifort 19.0.0.117 version detection.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         ifort (IFORT) 19.0.0.117 20180804
         Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
 
     """)
     ifort = Ifort()
     with mock.patch.object(ifort, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         assert ifort.get_version() == (19, 0, 0, 117)
 
 
 def test_ifort_get_version_with_icc_string():
     '''Tests the ifort class with an icc version output.'''
-    full_version_string = dedent("""
+    full_version_output = dedent("""
         icc (ICC) 2021.10.0 20230609
         Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.
 
     """)
     ifort = Ifort()
     with mock.patch.object(ifort, "run",
-                           mock.Mock(return_value=full_version_string)):
+                           mock.Mock(return_value=full_version_output)):
         with pytest.raises(RuntimeError) as err:
             ifort.get_version()
-        assert "Unexpected version for ifort compiler" in str(err.value)
+        assert "Unexpected version output format for compiler" in str(err.value)
 
 
 # ============================================================================

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -47,15 +47,13 @@ class TestCompilerCheckAvailable:
         with mock.patch.object(cc, "get_version", returncode=(1, 2, 3)):
             assert cc.check_available()
 
-
     def test_available_after_error(self):
-        ''' Check the compiler is not available when get_version raises an 
+        ''' Check the compiler is not available when get_version raises an
         error
         '''
         cc = CCompiler("gcc", "gcc", "gnu")
         with mock.patch.object(cc, "get_version", side_effect=RuntimeError("")):
             assert not cc.check_available()
-
 
     def test_unavailable_when_version_missing(self):
         ''' Check the compiler is not available when get_version returns an
@@ -82,6 +80,7 @@ def test_compiler_hash():
     cc._name = "new_name"
     hash3 = cc.get_hash()
     assert hash3 not in (hash1, hash2)
+
 
 # TODO: Do we need this, or can it raise an error?
 def test_compiler_hash_missing_version():

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -65,10 +65,10 @@ def test_compiler_hash():
         hash2 = cc.get_hash()
         assert hash2 != hash1
 
-    # A change in the name must change the hash, again:
-    cc._name = "new_name"
-    hash3 = cc.get_hash()
-    assert hash3 not in (hash1, hash2)
+        # A change in the name must change the hash, again:
+        cc._name = "new_name"
+        hash3 = cc.get_hash()
+        assert hash3 not in (hash1, hash2)
 
 
 def test_compiler_hash_compiler_error():
@@ -158,7 +158,7 @@ class TestGetCompilerVersion:
         '''Checks if the correct error is raised from the given invalid
         full_version_string.
         '''
-        c = Compiler("gfortran", "gfortran", "gnu", Category.FORTRAN_COMPILER)
+        c = Compiler("Foo Fortran", "footran", "gnu", Category.FORTRAN_COMPILER)
         with mock.patch.object(c, "run",
                                mock.Mock(return_value=full_version_string)):
             with pytest.raises(RuntimeError) as err:
@@ -169,7 +169,7 @@ class TestGetCompilerVersion:
         '''Checks if the correct version is extracted from the given
         full_version_string.
         '''
-        c = Compiler("gfortran", "gfortran", "gnu", Category.FORTRAN_COMPILER)
+        c = Compiler("Foo Fortran", "footran", "gnu", Category.FORTRAN_COMPILER)
         with mock.patch.object(c, "run",
                                mock.Mock(return_value=full_version_string)):
             assert c.get_version() == expected
@@ -181,26 +181,27 @@ class TestGetCompilerVersion:
 
     def test_command_failure(self):
         '''If the version command fails, we must raise an error.'''
-        c = Compiler("gfortran", "gfortran", "gnu",
+        c = Compiler("Foo Fortran", "footran", "gnu",
                      Category.FORTRAN_COMPILER)
         with mock.patch.object(c, 'run', side_effect=RuntimeError()):
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError) as err:
                 c.get_version()
+            assert "Error asking for version of compiler" in str(err.value)
 
     def test_file_not_found(self):
         '''If the compiler is not found, we must raise an error.'''
-        c = Compiler("gfortran", "gfortran", "gnu",
+        c = Compiler("Foo Fortran", "footran", "gnu",
                      Category.FORTRAN_COMPILER)
         with mock.patch.object(c, 'run', side_effect=FileNotFoundError()):
             with pytest.raises(RuntimeError) as err:
                 c.get_version()
-            assert "Compiler not found: gfortran" in str(err.value)
+            assert "Compiler not found: Foo Fortran" in str(err.value)
 
     def test_unknown_command_response(self):
         '''If the full version output is in an unknown format,
         we must raise an error.'''
-        full_version_string = 'foo fortran 1.2.3'
-        expected_error = "Unexpected version response from compiler 'gfortran'"
+        full_version_string = 'Foo Fortran 1.2.3'
+        expected_error = "Unexpected version response from compiler 'Foo Fortran'"
         self._check_error(
             full_version_string=full_version_string,
             expected_error=expected_error
@@ -213,7 +214,7 @@ class TestGetCompilerVersion:
             Foo Fortran (Foo) 5 123456 (Foo Hat 4.8.5-44)
             Copyright (C) 2022 Foo Software Foundation, Inc.
         """)
-        expected_error = "Unhandled compiler version format for compiler 'gfortran'"
+        expected_error = "Unexpected compiler version format for compiler 'Foo Fortran'"
         self._check_error(
             full_version_string=full_version_string,
             expected_error=expected_error
@@ -225,7 +226,7 @@ class TestGetCompilerVersion:
             Foo Fortran (Foo) 5.1f.2g (Foo Hat 4.8.5)
             Copyright (C) 2022 Foo Software Foundation, Inc.
         """)
-        expected_error = "Unhandled compiler version format for compiler 'gfortran'"
+        expected_error = "Unexpected compiler version format for compiler 'Foo Fortran'"
         self._check_error(
             full_version_string=full_version_string,
             expected_error=expected_error
@@ -238,7 +239,7 @@ class TestGetCompilerVersion:
             Foo Fortran (Foo) 77
             Copyright (C) 2022 Foo Software Foundation, Inc.
         """)
-        expected_error = "Unhandled compiler version format for compiler 'gfortran'"
+        expected_error = "Unexpected compiler version format for compiler 'Foo Fortran'"
         self._check_error(
             full_version_string=full_version_string,
             expected_error=expected_error
@@ -247,120 +248,27 @@ class TestGetCompilerVersion:
     def test_2_part_version(self):
         '''Test major.minor format. '''
         full_version_string = dedent("""
-            Foo Fortran (Foo) 5.6 123456 (Foo Hat 4.8.5-44)
+            Foo Fortran (Foo) 5.6 123456 (Foo Hat 1.2.3-45)
             Copyright (C) 2022 Foo Software Foundation, Inc.
         """)
         self._check(full_version_string=full_version_string, expected=(5, 6))
 
-    # Possibly overkill to cover so many gfortran versions but I had to go
-    # check them so might as well add them.
-    # Note: different sources, e.g conda, change the output slightly...
-
-    def test_gfortran_4(self):
-        '''Test gfortran 4.8.5 version detection.'''
+    def test_3_part_version(self):
+        '''Test major.minor.patch format. '''
         full_version_string = dedent("""
-            GNU Fortran (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
-            Copyright (C) 2015 Free Software Foundation, Inc.
-
-            GNU Fortran comes with NO WARRANTY, to the extent permitted by law.
-            You may redistribute copies of GNU Fortran
-            under the terms of the GNU General Public License.
-            For more information about these matters, see the file named COPYING
-
+            Foo Fortran (Foo) 6.1.0
         """)
-
-        self._check(full_version_string=full_version_string, expected=(4, 8, 5))
-
-    def test_gfortran_6(self):
-        '''Test gfortran 6.1.0 version detection.'''
-        full_version_string = dedent("""
-            GNU Fortran (GCC) 6.1.0
-            Copyright (C) 2016 Free Software Foundation, Inc.
-            This is free software; see the source for copying conditions.  There is NO
-            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-        """)
-
         self._check(full_version_string=full_version_string, expected=(6, 1, 0))
 
-    def test_gfortran_8(self):
-        '''Test gfortran 8.5.0 version detection.'''
+    def test_4_part_version(self):
+        '''Test major.minor.patch.revision format. '''
         full_version_string = dedent("""
-            GNU Fortran (conda-forge gcc 8.5.0-16) 8.5.0
-            Copyright (C) 2018 Free Software Foundation, Inc.
-            This is free software; see the source for copying conditions.  There is NO
-            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
+            Foo Fortran (Foo) 19.0.0.117 20180804
         """)
-
-        self._check(full_version_string=full_version_string, expected=(8, 5, 0))
-
-    def test_gfortran_10(self):
-        '''Test gfortran 10.4.0 version detection.'''
-        full_version_string = dedent("""
-            GNU Fortran (conda-forge gcc 10.4.0-16) 10.4.0
-            Copyright (C) 2020 Free Software Foundation, Inc.
-            This is free software; see the source for copying conditions.  There is NO
-            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-        """)
-
-        self._check(full_version_string=full_version_string, expected=(10, 4, 0))
-
-    def test_gfortran_12(self):
-        '''Test gfortran 12.1.0 version detection.'''
-        full_version_string = dedent("""
-            GNU Fortran (conda-forge gcc 12.1.0-16) 12.1.0
-            Copyright (C) 2022 Free Software Foundation, Inc.
-            This is free software; see the source for copying conditions.  There is NO
-            warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-        """)
-
-        self._check(full_version_string=full_version_string, expected=(12, 1, 0))
-
-    def test_ifort_14(self):
-        '''Test ifort 14.0.3 version detection.'''
-        full_version_string = dedent("""
-            ifort (IFORT) 14.0.3 20140422
-            Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.
-
-        """)
-
-        self._check(full_version_string=full_version_string, expected=(14, 0, 3))
-
-    def test_ifort_15(self):
-        '''Test ifort 15.0.2 version detection.'''
-        full_version_string = dedent("""
-            ifort (IFORT) 15.0.2 20150121
-            Copyright (C) 1985-2015 Intel Corporation.  All rights reserved.
-
-        """)
-
-        self._check(full_version_string=full_version_string, expected=(15, 0, 2))
-
-    def test_ifort_17(self):
-        '''Test ifort 17.0.7 version detection.'''
-        full_version_string = dedent("""
-            ifort (IFORT) 17.0.7 20180403
-            Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
-
-        """)
-
-        self._check(full_version_string=full_version_string, expected=(17, 0, 7))
-
-    def test_ifort_19(self):
-        '''Test ifort 19.0.0.117 version detection.'''
-        full_version_string = dedent("""
-            ifort (IFORT) 19.0.0.117 20180804
-            Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
-
-        """)
-
-        self._check(full_version_string=full_version_string,
-                    expected=(19, 0, 0, 117))
+        self._check(full_version_string=full_version_string, expected=(19, 0, 0, 117))
 
 
+# ============================================================================
 def test_gcc():
     '''Tests the gcc class.'''
     gcc = Gcc()
@@ -369,6 +277,34 @@ def test_gcc():
     assert gcc.category == Category.C_COMPILER
 
 
+def test_gcc_get_version():
+    '''Tests the gcc class.'''
+    gcc = Gcc()
+    full_version_string = dedent("""
+        gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20)
+        Copyright (C) 2018 Free Software Foundation, Inc.
+    """)
+    with mock.patch.object(gcc, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert gcc.get_version() == (8, 5, 0)
+
+
+def test_gcc_get_version_with_icc_string():
+    '''Tests the gcc class.'''
+    gcc = Gcc()
+    full_version_string = dedent("""
+        icc (ICC) 2021.10.0 20230609
+        Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.
+
+    """)
+    with mock.patch.object(gcc, "run",
+                           mock.Mock(return_value=full_version_string)):
+        with pytest.raises(RuntimeError) as err:
+            gcc.get_version()
+        assert "Unexpected version for gcc compiler" in str(err.value)
+
+
+# ============================================================================
 def test_gfortran():
     '''Tests the gfortran class.'''
     gfortran = Gfortran()
@@ -377,6 +313,105 @@ def test_gfortran():
     assert gfortran.category == Category.FORTRAN_COMPILER
 
 
+# Possibly overkill to cover so many gfortran versions but I had to go
+# check them so might as well add them.
+# Note: different sources, e.g conda, change the output slightly...
+
+
+def test_gfortran_get_version_4():
+    '''Test gfortran 4.8.5 version detection.'''
+    full_version_string = dedent("""
+        GNU Fortran (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
+        Copyright (C) 2015 Free Software Foundation, Inc.
+
+        GNU Fortran comes with NO WARRANTY, to the extent permitted by law.
+        You may redistribute copies of GNU Fortran
+        under the terms of the GNU General Public License.
+        For more information about these matters, see the file named COPYING
+
+    """)
+    gfortran = Gfortran()
+    with mock.patch.object(gfortran, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert gfortran.get_version() == (4, 8, 5)
+
+
+def test_gfortran_get_version_6():
+    '''Test gfortran 6.1.0 version detection.'''
+    full_version_string = dedent("""
+        GNU Fortran (GCC) 6.1.0
+        Copyright (C) 2016 Free Software Foundation, Inc.
+        This is free software; see the source for copying conditions.  There is NO
+        warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    """)
+    gfortran = Gfortran()
+    with mock.patch.object(gfortran, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert gfortran.get_version() == (6, 1, 0)
+
+
+def test_gfortran_get_version_8():
+    '''Test gfortran 8.5.0 version detection.'''
+    full_version_string = dedent("""
+        GNU Fortran (conda-forge gcc 8.5.0-16) 8.5.0
+        Copyright (C) 2018 Free Software Foundation, Inc.
+        This is free software; see the source for copying conditions.  There is NO
+        warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    """)
+    gfortran = Gfortran()
+    with mock.patch.object(gfortran, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert gfortran.get_version() == (8, 5, 0)
+
+
+def test_gfortran_get_version_10():
+    '''Test gfortran 10.4.0 version detection.'''
+    full_version_string = dedent("""
+        GNU Fortran (conda-forge gcc 10.4.0-16) 10.4.0
+        Copyright (C) 2020 Free Software Foundation, Inc.
+        This is free software; see the source for copying conditions.  There is NO
+        warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    """)
+    gfortran = Gfortran()
+    with mock.patch.object(gfortran, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert gfortran.get_version() == (10, 4, 0)
+
+
+def test_gfortran_get_version_12():
+    '''Test gfortran 12.1.0 version detection.'''
+    full_version_string = dedent("""
+        GNU Fortran (conda-forge gcc 12.1.0-16) 12.1.0
+        Copyright (C) 2022 Free Software Foundation, Inc.
+        This is free software; see the source for copying conditions.  There is NO
+        warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    """)
+    gfortran = Gfortran()
+    with mock.patch.object(gfortran, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert gfortran.get_version() == (12, 1, 0)
+
+
+def test_gfortran_get_version_with_ifort_string():
+    '''Tests the gfortran class with an ifort version string.'''
+    full_version_string = dedent("""
+        ifort (IFORT) 14.0.3 20140422
+        Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.
+
+    """)
+    gfortran = Gfortran()
+    with mock.patch.object(gfortran, "run",
+                           mock.Mock(return_value=full_version_string)):
+        with pytest.raises(RuntimeError) as err:
+            gfortran.get_version()
+        assert "Unexpected version for gfortran compiler" in str(err.value)
+
+
+# ============================================================================
 def test_icc():
     '''Tests the icc class.'''
     icc = Icc()
@@ -385,6 +420,34 @@ def test_icc():
     assert icc.category == Category.C_COMPILER
 
 
+def test_icc_get_version():
+    '''Tests the icc class get_version method.'''
+    full_version_string = dedent("""
+        icc (ICC) 2021.10.0 20230609
+        Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.
+
+    """)
+    icc = Icc()
+    with mock.patch.object(icc, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert icc.get_version() == (2021, 10, 0)
+
+
+def test_icc_get_version_with_gcc_string():
+    '''Tests the icc class with a GCC version string.'''
+    full_version_string = dedent("""
+        gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20)
+        Copyright (C) 2018 Free Software Foundation, Inc.
+    """)
+    icc = Icc()
+    with mock.patch.object(icc, "run",
+                           mock.Mock(return_value=full_version_string)):
+        with pytest.raises(RuntimeError) as err:
+            icc.get_version()
+        assert "Unexpected version for icc compiler" in str(err.value)
+
+
+# ============================================================================
 def test_ifort():
     '''Tests the ifort class.'''
     ifort = Ifort()
@@ -393,6 +456,71 @@ def test_ifort():
     assert ifort.category == Category.FORTRAN_COMPILER
 
 
+def test_ifort_get_version_14():
+    '''Test ifort 14.0.3 version detection.'''
+    full_version_string = dedent("""
+        ifort (IFORT) 14.0.3 20140422
+        Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.
+
+    """)
+    ifort = Ifort()
+    with mock.patch.object(ifort, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert ifort.get_version() == (14, 0, 3)
+
+def test_ifort_get_version_15():
+    '''Test ifort 15.0.2 version detection.'''
+    full_version_string = dedent("""
+        ifort (IFORT) 15.0.2 20150121
+        Copyright (C) 1985-2015 Intel Corporation.  All rights reserved.
+
+    """)
+    ifort = Ifort()
+    with mock.patch.object(ifort, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert ifort.get_version() == (15, 0, 2)
+
+def test_ifort_get_version_17():
+    '''Test ifort 17.0.7 version detection.'''
+    full_version_string = dedent("""
+        ifort (IFORT) 17.0.7 20180403
+        Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
+
+    """)
+    ifort = Ifort()
+    with mock.patch.object(ifort, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert ifort.get_version() == (17, 0, 7)
+
+def test_ifort_get_version_19():
+    '''Test ifort 19.0.0.117 version detection.'''
+    full_version_string = dedent("""
+        ifort (IFORT) 19.0.0.117 20180804
+        Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
+
+    """)
+    ifort = Ifort()
+    with mock.patch.object(ifort, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert ifort.get_version() == (19, 0, 0, 117)
+
+
+def test_ifort_get_version_with_icc_string():
+    '''Tests the icc class.'''
+    full_version_string = dedent("""
+        icc (ICC) 2021.10.0 20230609
+        Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.
+
+    """)
+    ifort = Ifort()
+    with mock.patch.object(ifort, "run",
+                           mock.Mock(return_value=full_version_string)):
+        with pytest.raises(RuntimeError) as err:
+            ifort.get_version()
+        assert "Unexpected version for ifort compiler" in str(err.value)
+
+
+# ============================================================================
 def test_compiler_wrapper():
     '''Make sure we can easily create a compiler wrapper.'''
     class MpiF90(Ifort):

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -35,33 +35,32 @@ def test_compiler():
     assert fc.flags == []
 
 
-class TestCompilerCheckAvailable:
-    '''Check if check_available works as expected. The compiler class
-    uses internally get_version to test if a compiler works or not.
+def test_available():
+    '''Check if check_available works as expected. The compiler class uses
+    internally get_version to test if a compiler works or not. Check the
+    compiler is available when it has a valid version.
     '''
+    cc = CCompiler("gcc", "gcc", "gnu")
+    with mock.patch.object(cc, "get_version", returncode=(1, 2, 3)):
+        assert cc.check_available()
 
-    def test_available(self):
-        ''' Check the compiler is available when it has a valid version
-        '''
-        cc = CCompiler("gcc", "gcc", "gnu")
-        with mock.patch.object(cc, "get_version", returncode=(1, 2, 3)):
-            assert cc.check_available()
 
-    def test_available_after_error(self):
-        ''' Check the compiler is not available when get_version raises an
-        error
-        '''
-        cc = CCompiler("gcc", "gcc", "gnu")
-        with mock.patch.object(cc, "get_version", side_effect=RuntimeError("")):
-            assert not cc.check_available()
+def test_available_after_error():
+    ''' Check the compiler is not available when get_version raises an
+    error.
+    '''
+    cc = CCompiler("gcc", "gcc", "gnu")
+    with mock.patch.object(cc, "get_version", side_effect=RuntimeError("")):
+        assert not cc.check_available()
 
-    def test_unavailable_when_version_missing(self):
-        ''' Check the compiler is not available when get_version returns an
-        empty version
-        '''
-        cc = CCompiler("gcc", "gcc", "gnu")
-        with mock.patch.object(cc, "_version", tuple()):
-            assert not cc.check_available()
+
+def test_unavailable_when_version_missing():
+    ''' Check the compiler is not available when get_version returns an
+    empty version.
+    '''
+    cc = CCompiler("gcc", "gcc", "gnu")
+    with mock.patch.object(cc, "_version", tuple()):
+        assert not cc.check_available()
 
 
 def test_compiler_hash():
@@ -82,7 +81,7 @@ def test_compiler_hash():
     assert hash3 not in (hash1, hash2)
 
 
-# TODO: Do we need this, or can it raise an error?
+# TODO: Do we need to support this, or can it raise an error?
 def test_compiler_hash_missing_version():
     '''Test the hash functionality when version info is missing.'''
     cc = CCompiler("gcc", "gcc", "gnu")

--- a/tests/unit_tests/tools/test_compiler.py
+++ b/tests/unit_tests/tools/test_compiler.py
@@ -77,8 +77,9 @@ def test_compiler_hash_compiler_error():
 
     # raise an error when trying to get compiler version
     with mock.patch.object(cc, 'run', side_effect=RuntimeError()):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as err:
             cc.get_hash()
+            assert "Error asking for version of compiler" in str(err.value)
 
 
 def test_compiler_hash_invalid_version():
@@ -87,8 +88,9 @@ def test_compiler_hash_invalid_version():
 
     # returns an invalid compiler version string
     with mock.patch.object(cc, "run", mock.Mock(return_value='foo v1')):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as err:
             cc.get_hash()
+            assert "Unexpected version response from compiler 'gcc'" in str(err.value)
 
 
 def test_compiler_with_env_fflags():
@@ -265,7 +267,22 @@ class TestGetCompilerVersion:
         full_version_string = dedent("""
             Foo Fortran (Foo) 19.0.0.117 20180804
         """)
-        self._check(full_version_string=full_version_string, expected=(19, 0, 0, 117))
+        self._check(
+            full_version_string=full_version_string,
+            expected=(19, 0, 0, 117)
+        )
+
+
+def test_get_version_string():
+    '''Tests the compiler get_version_string() method.
+    '''
+    full_version_string = dedent("""
+        Foo Fortran (Foo) 6.1.0
+    """)
+    c = Compiler("Foo Fortran", "footran", "gnu", Category.FORTRAN_COMPILER)
+    with mock.patch.object(c, "run",
+                           mock.Mock(return_value=full_version_string)):
+        assert c.get_version_string() == "6.1.0"
 
 
 # ============================================================================
@@ -278,7 +295,7 @@ def test_gcc():
 
 
 def test_gcc_get_version():
-    '''Tests the gcc class.'''
+    '''Tests the gcc class get_version method.'''
     gcc = Gcc()
     full_version_string = dedent("""
         gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20)
@@ -290,7 +307,7 @@ def test_gcc_get_version():
 
 
 def test_gcc_get_version_with_icc_string():
-    '''Tests the gcc class.'''
+    '''Tests the gcc class with an icc version output.'''
     gcc = Gcc()
     full_version_string = dedent("""
         icc (ICC) 2021.10.0 20230609
@@ -397,7 +414,7 @@ def test_gfortran_get_version_12():
 
 
 def test_gfortran_get_version_with_ifort_string():
-    '''Tests the gfortran class with an ifort version string.'''
+    '''Tests the gfortran class with an ifort version output.'''
     full_version_string = dedent("""
         ifort (IFORT) 14.0.3 20140422
         Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.
@@ -434,7 +451,7 @@ def test_icc_get_version():
 
 
 def test_icc_get_version_with_gcc_string():
-    '''Tests the icc class with a GCC version string.'''
+    '''Tests the icc class with a GCC version output.'''
     full_version_string = dedent("""
         gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20)
         Copyright (C) 2018 Free Software Foundation, Inc.
@@ -509,7 +526,7 @@ def test_ifort_get_version_19():
 
 
 def test_ifort_get_version_with_icc_string():
-    '''Tests the icc class.'''
+    '''Tests the ifort class with an icc version output.'''
     full_version_string = dedent("""
         icc (ICC) 2021.10.0 20230609
         Copyright (C) 1985-2023 Intel Corporation.  All rights reserved.


### PR DESCRIPTION
Handles Issue #8 

When retrieving a compiler version, the compiler class will now:

 * check that the `--version` output contains a particular identifier for the expected compiler. By default this is `compiler.name`, but it can be overridden for each compiler with a new `version_token` argument in the constructor (required for `gfort` which outputs `GNU Fortran`)
 * return the components of the version as a tuple (previously a string)
 * raise an error for any unexpected formatting of the `--version` output (previously it would return an empty string in some cases)

