### PR TITLE
Linker flags for common libraries

### DIFF
--- a/Documentation/source/advanced_config.rst
+++ b/Documentation/source/advanced_config.rst
@@ -193,6 +193,14 @@ to specify 3rd party libraries at the link stage.
 
     link_exe(state, flags=['-lm', '-lnetcdf'])
 
+Linkers will be pre-configured with flags for common libraries. Where possible,
+a library name should be used to include the required flags for linking.
+
+.. code-block::
+    :linenos:
+
+    link_exe(state, libs=['netcdf'])
+
 Path-specific flags
 -------------------
 

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -72,7 +72,7 @@ def link_exe(config,
     for root, objects in target_objects.items():
         exe_path = config.project_workspace / f'{root}'
         linker.link(objects, exe_path, openmp=config.openmp, libs=libs,
-                    add_flags=flags)
+                    post_lib_flags=flags)
         config.artefact_store.add(ArtefactSet.EXECUTABLES, exe_path)
 
 
@@ -122,4 +122,4 @@ def link_shared_object(config, output_fpath: str, flags=None,
 
     objects = target_objects[None]
     out_name = Template(output_fpath).substitute(output=config.build_output)
-    linker.link(objects, out_name, openmp=config.openmp, add_flags=flags)
+    linker.link(objects, out_name, openmp=config.openmp, post_lib_flags=flags)

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -9,7 +9,7 @@ Link an executable.
 """
 import logging
 from string import Template
-from typing import Optional
+from typing import Optional, Union
 
 from fab.artefacts import ArtefactSet
 from fab.steps import step
@@ -33,7 +33,10 @@ class DefaultLinkerSource(ArtefactsGetter):
 
 
 @step
-def link_exe(config, flags=None, source: Optional[ArtefactsGetter] = None):
+def link_exe(config,
+             libs: Union[list[str], None] = None,
+             flags: Union[list[str], None] = None,
+             source: Optional[ArtefactsGetter] = None):
     """
     Link object files into an executable for every build target.
 
@@ -49,8 +52,10 @@ def link_exe(config, flags=None, source: Optional[ArtefactsGetter] = None):
         The :class:`fab.build_config.BuildConfig` object where we can read
         settings such as the project workspace folder or the multiprocessing
         flag.
+    :param libs:
+        A list of required library names to pass to the linker.
     :param flags:
-        A list of flags to pass to the linker.
+        A list of additional flags to pass to the linker.
     :param source:
         An optional :class:`~fab.artefacts.ArtefactsGetter`. It defaults to the
         output from compiler steps, which typically is the expected behaviour.
@@ -59,13 +64,15 @@ def link_exe(config, flags=None, source: Optional[ArtefactsGetter] = None):
     linker = config.tool_box.get_tool(Category.LINKER, config.mpi)
     logger.info(f'Linker is {linker.name}')
 
+    libs = libs or []
     flags = flags or []
     source_getter = source or DefaultLinkerSource()
 
     target_objects = source_getter(config.artefact_store)
     for root, objects in target_objects.items():
         exe_path = config.project_workspace / f'{root}'
-        linker.link(objects, exe_path, openmp=config.openmp, add_flags=flags)
+        linker.link(objects, exe_path, openmp=config.openmp, libs=libs,
+                    add_flags=flags)
         config.artefact_store.add(ArtefactSet.EXECUTABLES, exe_path)
 
 

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -65,14 +65,14 @@ def link_exe(config,
     logger.info(f'Linker is {linker.name}')
 
     libs = libs or []
-    flags = flags or []
+    if flags:
+        linker.add_post_lib_flags(flags)
     source_getter = source or DefaultLinkerSource()
 
     target_objects = source_getter(config.artefact_store)
     for root, objects in target_objects.items():
         exe_path = config.project_workspace / f'{root}'
-        linker.link(objects, exe_path, openmp=config.openmp, libs=libs,
-                    post_lib_flags=flags)
+        linker.link(objects, exe_path, openmp=config.openmp, libs=libs)
         config.artefact_store.add(ArtefactSet.EXECUTABLES, exe_path)
 
 
@@ -122,4 +122,5 @@ def link_shared_object(config, output_fpath: str, flags=None,
 
     objects = target_objects[None]
     out_name = Template(output_fpath).substitute(output=config.build_output)
-    linker.link(objects, out_name, openmp=config.openmp, post_lib_flags=flags)
+    linker.add_post_lib_flags(flags)
+    linker.link(objects, out_name, openmp=config.openmp)

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -9,7 +9,7 @@ Link an executable.
 """
 import logging
 from string import Template
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from fab.artefacts import ArtefactSet
 from fab.steps import step
@@ -34,8 +34,8 @@ class DefaultLinkerSource(ArtefactsGetter):
 
 @step
 def link_exe(config,
-             libs: Union[list[str], None] = None,
-             flags: Union[list[str], None] = None,
+             libs: Union[List[str], None] = None,
+             flags: Union[List[str], None] = None,
              source: Optional[ArtefactsGetter] = None):
     """
     Link object files into an executable for every build target.

--- a/source/fab/steps/link.py
+++ b/source/fab/steps/link.py
@@ -65,7 +65,7 @@ def link_exe(config, flags=None, source: Optional[ArtefactsGetter] = None):
     target_objects = source_getter(config.artefact_store)
     for root, objects in target_objects.items():
         exe_path = config.project_workspace / f'{root}'
-        linker.link(objects, exe_path, openmp=config.openmp, add_libs=flags)
+        linker.link(objects, exe_path, openmp=config.openmp, add_flags=flags)
         config.artefact_store.add(ArtefactSet.EXECUTABLES, exe_path)
 
 
@@ -115,4 +115,4 @@ def link_shared_object(config, output_fpath: str, flags=None,
 
     objects = target_objects[None]
     out_name = Template(output_fpath).substitute(output=config.build_output)
-    linker.link(objects, out_name, openmp=config.openmp, add_libs=flags)
+    linker.link(objects, out_name, openmp=config.openmp, add_flags=flags)

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -80,6 +80,9 @@ class Linker(CompilerSuiteTool):
         except KeyError:
             raise RuntimeError(f"Unknown library name: '{lib}'")
 
+    def add_lib_flags(self, lib: str, flags: List[str]):
+        self.env_flags[lib] = flags
+
     def link(self, input_files: List[Path], output_file: Path,
              openmp: bool,
              add_libs: Optional[List[str]] = None) -> str:

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -54,11 +54,6 @@ class Linker(CompilerSuiteTool):
 
         # Maintain a set of flags for common libraries.
         self._lib_flags: Dict[str, List[str]] = {}
-        # Include netcdf as an example, since it is reasonable portable
-        self.add_lib_flags(
-            'netcdf',
-            ['$(nf-config --flibs)', '$(nc-config --libs)']
-        )
 
     @property
     def mpi(self) -> bool:

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -57,7 +57,7 @@ class Linker(CompilerSuiteTool):
         # Include netcdf as an example, since it is reasonable portable
         self.add_lib_flags(
             'netcdf',
-            ['$(nf-config --flibs)', '($nc-config --libs)']
+            ['$(nf-config --flibs)', '$(nc-config --libs)']
         )
 
     @property

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -81,7 +81,21 @@ class Linker(CompilerSuiteTool):
             raise RuntimeError(f"Unknown library name: '{lib}'")
 
     def add_lib_flags(self, lib: str, flags: List[str]):
+        '''Add a set of flags for a standard library
+
+        :param lib: the library name
+        :param flags: the flags to use with the library
+
+        '''
         self.env_flags[lib] = flags
+
+    def remove_lib_flags(self, lib: str):
+        '''Add a set of flags for a standard library
+
+        :param lib: the library name
+
+        '''
+        del self.env_flags[lib]
 
     def link(self, input_files: List[Path], output_file: Path,
              openmp: bool,

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -9,7 +9,7 @@
 
 import os
 from pathlib import Path
-from typing import cast, List, Optional
+from typing import cast, Dict, List, Optional
 
 from fab.tools.category import Category
 from fab.tools.compiler import Compiler
@@ -52,7 +52,7 @@ class Linker(CompilerSuiteTool):
         self.flags.extend(os.getenv("LDFLAGS", "").split())
 
         # Maintain a set of flags for common libraries.
-        self._lib_flags: dict[str, List[str]] = {}
+        self._lib_flags: Dict[str, List[str]] = {}
         # Include netcdf as an example, since it is reasonable portable
         self.add_lib_flags(
             'netcdf',

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -52,7 +52,7 @@ class Linker(CompilerSuiteTool):
         self.flags.extend(os.getenv("LDFLAGS", "").split())
 
         # Maintain a set of flags for common libraries.
-        self.lib_flags = {
+        self._lib_flags = {
             'netcdf': ['$(nf-config --flibs)', '($nc-config --libs)']
         }
 
@@ -76,7 +76,7 @@ class Linker(CompilerSuiteTool):
         :raises RuntimeError: if lib is not recognised
         '''
         try:
-            return self.lib_flags[lib]
+            return self._lib_flags[lib]
         except KeyError:
             raise RuntimeError(f"Unknown library name: '{lib}'")
 
@@ -87,7 +87,8 @@ class Linker(CompilerSuiteTool):
         :param flags: the flags to use with the library
 
         '''
-        self.lib_flags[lib] = flags
+        # Make a copy to avoid modifying the caller's list
+        self._lib_flags[lib] = flags[:]
 
     def remove_lib_flags(self, lib: str):
         '''Add a set of flags for a standard library
@@ -96,13 +97,13 @@ class Linker(CompilerSuiteTool):
 
         '''
         try:
-            del self.lib_flags[lib]
+            del self._lib_flags[lib]
         except KeyError:
             pass
 
     def link(self, input_files: List[Path], output_file: Path,
              openmp: bool,
-             add_libs: Optional[List[str]] = None,
+             libs: Optional[List[str]] = None,
              add_flags: Optional[List[str]] = None) -> str:
         '''Executes the linker with the specified input files,
         creating `output_file`.
@@ -110,7 +111,7 @@ class Linker(CompilerSuiteTool):
         :param input_files: list of input files to link.
         :param output_file: output file.
         :param openm: whether OpenMP is requested or not.
-        :param add_libs: additional libraries to link with.
+        :param libs: additional libraries to link with.
         :param add_flags: additional linker flags.
 
         :returns: the stdout of the link command
@@ -124,9 +125,9 @@ class Linker(CompilerSuiteTool):
             params = []
         # TODO: why are the .o files sorted? That shouldn't matter
         params.extend(sorted(map(str, input_files)))
-        for lib in add_libs or []:
-            params += self.lib_flags[lib]
+        for lib in libs or []:
+            params.extend(self._lib_flags[lib])
         if add_flags:
-            params += add_flags
+            params.extend(add_flags)
         params.extend([self._output_flag, str(output_file)])
         return self.run(params)

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -52,9 +52,12 @@ class Linker(CompilerSuiteTool):
         self.flags.extend(os.getenv("LDFLAGS", "").split())
 
         # Maintain a set of flags for common libraries.
-        self._lib_flags = {
-            'netcdf': ['$(nf-config --flibs)', '($nc-config --libs)']
-        }
+        self._lib_flags = {}
+        # Include netcdf as an example, since it is reasonable portable
+        self.add_lib_flags(
+            'netcdf',
+            ['$(nf-config --flibs)', '($nc-config --libs)']
+        )
 
     def check_available(self) -> bool:
         '''
@@ -85,7 +88,6 @@ class Linker(CompilerSuiteTool):
 
         :param lib: the library name
         :param flags: the flags to use with the library
-
         '''
         # Make a copy to avoid modifying the caller's list
         self._lib_flags[lib] = flags[:]
@@ -94,7 +96,6 @@ class Linker(CompilerSuiteTool):
         '''Add a set of flags for a standard library
 
         :param lib: the library name
-
         '''
         try:
             del self._lib_flags[lib]
@@ -125,8 +126,9 @@ class Linker(CompilerSuiteTool):
             params = []
         # TODO: why are the .o files sorted? That shouldn't matter
         params.extend(sorted(map(str, input_files)))
-        for lib in libs or []:
-            params.extend(self._lib_flags[lib])
+
+        for lib in (libs or []):
+            params.extend(self.get_lib_flags(lib))
         if add_flags:
             params.extend(add_flags)
         params.extend([self._output_flag, str(output_file)])

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -10,6 +10,7 @@
 import os
 from pathlib import Path
 from typing import cast, Dict, List, Optional
+import warnings
 
 from fab.tools.category import Category
 from fab.tools.compiler import Compiler
@@ -83,12 +84,20 @@ class Linker(CompilerSuiteTool):
         except KeyError:
             raise RuntimeError(f"Unknown library name: '{lib}'")
 
-    def add_lib_flags(self, lib: str, flags: List[str]):
+    def add_lib_flags(self, lib: str, flags: List[str],
+                      silent_replace: bool = False):
         '''Add a set of flags for a standard library
 
         :param lib: the library name
         :param flags: the flags to use with the library
+        :param silent_replace: if set, no warning will be printed when an
+            existing lib is overwritten.
         '''
+        if lib in self._lib_flags and not silent_replace:
+            warnings.warn(f"Replacing existing flags for library {lib}: "
+                          f"'{self._lib_flags[lib]}' with "
+                          f"'{flags}'.")
+
         # Make a copy to avoid modifying the caller's list
         self._lib_flags[lib] = flags[:]
 

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -51,6 +51,11 @@ class Linker(CompilerSuiteTool):
         self._compiler = compiler
         self.flags.extend(os.getenv("LDFLAGS", "").split())
 
+        # Maintain a set of flags for common libraries.
+        self.env_flags = {
+            'netcdf': ['$(nf-config --flibs)', '($nc-config --libs)']
+        }
+
     def check_available(self) -> bool:
         '''
         :returns: whether the linker is available or not. We do this
@@ -60,6 +65,20 @@ class Linker(CompilerSuiteTool):
             return self._compiler.check_available()
 
         return super().check_available()
+
+    def get_lib_flags(self, lib: str) -> List[str]:
+        '''Gets the standard flags for a standard library
+
+        :param lib: the library name
+
+        :returns: a list of flags
+
+        :raises RuntimeError: if lib is not recognised
+        '''
+        try:
+            return self.env_flags[lib]
+        except KeyError:
+            raise RuntimeError(f"Unknown library name: '{lib}'")
 
     def link(self, input_files: List[Path], output_file: Path,
              openmp: bool,

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -52,7 +52,7 @@ class Linker(CompilerSuiteTool):
         self.flags.extend(os.getenv("LDFLAGS", "").split())
 
         # Maintain a set of flags for common libraries.
-        self._lib_flags = {}
+        self._lib_flags: dict[str, List[str]] = {}
         # Include netcdf as an example, since it is reasonable portable
         self.add_lib_flags(
             'netcdf',

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -118,16 +118,18 @@ class Linker(CompilerSuiteTool):
 
     def link(self, input_files: List[Path], output_file: Path,
              openmp: bool,
+             pre_lib_flags: Optional[List[str]] = None,
              libs: Optional[List[str]] = None,
-             add_flags: Optional[List[str]] = None) -> str:
+             post_lib_flags: Optional[List[str]] = None) -> str:
         '''Executes the linker with the specified input files,
         creating `output_file`.
 
         :param input_files: list of input files to link.
         :param output_file: output file.
         :param openm: whether OpenMP is requested or not.
+        :param pre_lib_flags: additional linker flags to use before libs.
         :param libs: additional libraries to link with.
-        :param add_flags: additional linker flags.
+        :param post_lib_flags: additional linker flags to use after libs.
 
         :returns: the stdout of the link command
         '''
@@ -141,9 +143,11 @@ class Linker(CompilerSuiteTool):
         # TODO: why are the .o files sorted? That shouldn't matter
         params.extend(sorted(map(str, input_files)))
 
+        if pre_lib_flags:
+            params.extend(pre_lib_flags)
         for lib in (libs or []):
             params.extend(self.get_lib_flags(lib))
-        if add_flags:
-            params.extend(add_flags)
+        if post_lib_flags:
+            params.extend(post_lib_flags)
         params.extend([self._output_flag, str(output_file)])
         return self.run(params)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def fixture_mock_linker():
                          Category.FORTRAN_COMPILER)
     mock_linker.run = mock.Mock()
     mock_linker._version = (1, 2, 3)
+    mock_linker.add_lib_flags('netcdf',
+                              ['$(nf-config --flibs)', '$(nc-config --libs)'])
     return mock_linker
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,7 @@ def fixture_mock_linker():
                          Category.FORTRAN_COMPILER)
     mock_linker.run = mock.Mock()
     mock_linker._version = (1, 2, 3)
-    mock_linker.add_lib_flags('netcdf',
-                              ['$(nf-config --flibs)', '$(nc-config --libs)'])
+    mock_linker.add_lib_flags("netcdf", ["-lnetcdff", "-lnetcdf"])
     return mock_linker
 
 

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -51,7 +51,8 @@ class TestArchiveObjects:
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
-            target: set([str(config.build_output / f'{target}.a')]) for target in targets}
+            target: set([str(config.build_output / f'{target}.a')])
+            for target in targets}
 
     def test_for_library(self):
         '''As used when building an object archive or archiving before linking
@@ -65,12 +66,15 @@ class TestArchiveObjects:
         mock_result = mock.Mock(returncode=0, return_value=123)
         with mock.patch('fab.tools.tool.subprocess.run',
                         return_value=mock_result) as mock_run_command, \
-                pytest.warns(UserWarning, match="_metric_send_conn not set, cannot send metrics"):
-            archive_objects(config=config, output_fpath=config.build_output / 'mylib.a')
+                pytest.warns(UserWarning, match="_metric_send_conn not set, "
+                                                "cannot send metrics"):
+            archive_objects(config=config,
+                            output_fpath=config.build_output / 'mylib.a')
 
         # ensure the correct command line calls were made
         mock_run_command.assert_called_once_with([
-            'ar', 'cr', str(config.build_output / 'mylib.a'), 'util1.o', 'util2.o'],
+            'ar', 'cr', str(config.build_output / 'mylib.a'), 'util1.o',
+            'util2.o'],
             capture_output=True, env=None, cwd=None, check=False)
 
         # ensure the correct artefacts were created

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -77,20 +77,21 @@ class TestArchiveObjects:
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
             None: set([str(config.build_output / 'mylib.a')])}
 
-    def test_incorrect_tool(self):
+    def test_incorrect_tool(self, mock_c_compiler):
         '''Test that an incorrect archive tool is detected
         '''
 
         config = BuildConfig('proj', ToolBox(), mpi=False, openmp=False)
         tool_box = config.tool_box
-        cc = tool_box.get_tool(Category.C_COMPILER, config.mpi)
-        # And set its category to C_COMPILER
+        cc = mock_c_compiler
+        # And set its category to be AR
         cc._category = Category.AR
-        # So overwrite the C compiler with the re-categories Fortran compiler
+        # Now add this 'ar' tool to the tool box
         tool_box.add_tool(cc)
 
         with pytest.raises(RuntimeError) as err:
             archive_objects(config=config,
                             output_fpath=config.build_output / 'mylib.a')
-        assert ("Unexpected tool 'gcc' of type '<class "
-                "'fab.tools.compiler.Gcc'>' instead of Ar" in str(err.value))
+        assert ("Unexpected tool 'mock_c_compiler' of type '<class "
+                "'fab.tools.compiler.CCompiler'>' instead of Ar"
+                in str(err.value))

--- a/tests/unit_tests/steps/test_link.py
+++ b/tests/unit_tests/steps/test_link.py
@@ -34,6 +34,9 @@ class TestLinkExe:
             linker = Linker("mock_link", "mock_link.exe", "mock-vendor")
             # Mark the linker as available to it can be added to the tool box
             linker._is_available = True
+
+            # Add a custom library to the linker
+            linker.add_lib_flags('mylib', ['-L/my/lib', '-mylib'])
             tool_box.add_tool(linker, silent_replace=True)
             mock_result = mock.Mock(returncode=0, stdout="abc\ndef".encode())
             with mock.patch('fab.tools.tool.subprocess.run',
@@ -41,9 +44,10 @@ class TestLinkExe:
                     pytest.warns(UserWarning,
                                  match="_metric_send_conn not "
                                        "set, cannot send metrics"):
-                link_exe(config, flags=['-fooflag', '-barflag'])
+                link_exe(config, libs=['mylib'], flags=['-fooflag', '-barflag'])
 
         tool_run.assert_called_with(
             ['mock_link.exe', '-L/foo1/lib', '-L/foo2/lib', 'bar.o', 'foo.o',
-             '-fooflag', '-barflag', '-o', 'workspace/foo'],
+             '-L/my/lib', '-mylib', '-fooflag', '-barflag',
+             '-o', 'workspace/foo'],
             capture_output=True, env=None, cwd=None, check=False)

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -146,7 +146,8 @@ def test_linker_get_lib_flags(mock_c_compiler):
     linker flags
     '''
     linker = Linker(compiler=mock_c_compiler)
-    assert linker.get_lib_flags('netcdf') == ['$(nf-config --flibs)', '($nc-config --libs)']
+    result = linker.get_lib_flags('netcdf')
+    assert result == ['$(nf-config --flibs)', '($nc-config --libs)']
 
 
 # If a library is specified that is unknown, raise an error.
@@ -160,12 +161,17 @@ def test_linker_get_lib_flags_unknown(mock_c_compiler):
     assert "Unknown library name" in str(err.value)
 
 
-# # There must be function to add and remove libraries (and Fab as default would
-# # likely provide none? Or Maybe just say netcdf as an example, since this is
-# # reasonable portable). Site-specific scripts will want to modify the settings
-# def test_linker_add_library_flags(mock_c_compiler):
-#     linker = Linker(compiler=mock_c_compiler)
-#     linker.add_lib_flags('xios', ['-L', 'xios/lib', '-l', 'xios/lib'])
+# There must be function to add and remove libraries (and Fab as default would
+# likely provide none? Or Maybe just say netcdf as an example, since this is
+# reasonable portable). Site-specific scripts will want to modify the settings
+def test_linker_add_library_flags(mock_c_compiler):
+    '''Linker should provide a way to add a new set of flags for a library '''
+    linker = Linker(compiler=mock_c_compiler)
+    linker.add_lib_flags('xios', ['-L', 'xios/lib', '-I', 'xios/inc'])
+
+    # Make sure we can get it back. The order should be maintained.
+    result = linker.get_lib_flags('xios')
+    assert result == ['-L', 'xios/lib', '-I', 'xios/inc']
 
 
 # # An application then only specifies which libraries it needs to link with (and

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -100,7 +100,7 @@ def test_linker_get_lib_flags(mock_c_compiler):
     linker = Linker(compiler=mock_c_compiler)
     # netcdf is built in to the linker, since it is reasonable portable
     result = linker.get_lib_flags("netcdf")
-    assert result == ["$(nf-config --flibs)", "($nc-config --libs)"]
+    assert result == ["$(nf-config --flibs)", "$(nc-config --libs)"]
 
 
 def test_linker_get_lib_flags_unknown(mock_c_compiler):
@@ -129,7 +129,7 @@ def test_linker_add_lib_flags_overwrite_defaults(mock_c_compiler):
 
     # Initially we have the default netcdf flags
     result = linker.get_lib_flags("netcdf")
-    assert result == ["$(nf-config --flibs)", "($nc-config --libs)"]
+    assert result == ["$(nf-config --flibs)", "$(nc-config --libs)"]
 
     # Replace them with another set of flags.
     warn_message = 'Replacing existing flags for library netcdf'
@@ -199,7 +199,7 @@ def test_linker_c_with_libraries(mock_c_compiler):
         linker.link([Path("a.o")], Path("a.out"), libs=["netcdf"], openmp=True)
     link_run.assert_called_with(
         ["-fopenmp", "a.o",
-         "$(nf-config --flibs)", "($nc-config --libs)",
+         "$(nf-config --flibs)", "$(nc-config --libs)",
          "-o", "a.out"])
 
 
@@ -215,7 +215,7 @@ def test_linker_c_with_libraries_and_post_flags(mock_c_compiler):
         )
     link_run.assert_called_with([
         "a.o",
-        "$(nf-config --flibs)", "($nc-config --libs)", "-extra-flag",
+        "$(nf-config --flibs)", "$(nc-config --libs)", "-extra-flag",
         "-o", "a.out",
     ])
 
@@ -232,7 +232,7 @@ def test_linker_c_with_libraries_and_pre_flags(mock_c_compiler):
         )
     link_run.assert_called_with([
         "a.o",
-        "-extra-flag", "$(nf-config --flibs)", "($nc-config --libs)",
+        "-extra-flag", "$(nf-config --flibs)", "$(nc-config --libs)",
         "-o", "a.out",
     ])
 
@@ -248,7 +248,7 @@ def test_linker_c_with_custom_libraries(mock_c_compiler):
     link_run.assert_called_with(
         ["-fopenmp", "a.o",
          "-q", "/tmp", "-j",
-         "$(nf-config --flibs)", "($nc-config --libs)",
+         "$(nf-config --flibs)", "$(nc-config --libs)",
          "-o", "a.out"])
 
 
@@ -328,7 +328,7 @@ def test_linker_all_flag_types(mock_c_compiler):
         "a.o",
         "-prelibflag1", "-prelibflag2",
         "-libflag1", "libflag2",
-        "$(nf-config --flibs)", "($nc-config --libs)",
+        "$(nf-config --flibs)", "$(nc-config --libs)",
         "-postlibflag1", "-postlibflag2",
         "-o", "a.out"],
         capture_output=True, env=None, cwd=None, check=False)

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -136,3 +136,53 @@ def test_linker_add_compiler_flag():
     tool_run.assert_called_with(
         ['no-compiler.exe', '-some-other-flag', 'a.o', '-o', 'a.out'],
         capture_output=True, env=None, cwd=None, check=False)
+
+# The linker base class should provide a dictionary that maps strings (which are
+# 'standard' library names) to a list of linker flags. E.g.
+#
+#    'netcdf' -> ['$(nf-config --flibs)', '($nc-config --libs)']
+def test_linker_get_lib_flags(mock_c_compiler):
+    '''Linker should provide a map of 'standard' library names to a list of
+    linker flags
+    '''
+    linker = Linker(compiler=mock_c_compiler)
+    assert linker.get_lib_flags('netcdf') == ['$(nf-config --flibs)', '($nc-config --libs)']
+
+
+# If a library is specified that is unknown, raise an error.
+def test_linker_get_lib_flags_unknown(mock_c_compiler):
+    '''Linker should raise an error if flags are requested for a library that is
+    unknown
+    '''
+    linker = Linker(compiler=mock_c_compiler)
+    with pytest.raises(RuntimeError) as err:
+        linker.get_lib_flags('unknown')
+    assert "Unknown library name" in str(err.value)
+
+
+# # There must be function to add and remove libraries (and Fab as default would
+# # likely provide none? Or Maybe just say netcdf as an example, since this is
+# # reasonable portable). Site-specific scripts will want to modify the settings
+# def test_linker_add_library_flags(mock_c_compiler):
+#     linker = Linker(compiler=mock_c_compiler)
+#     linker.add_lib_flags('xios', ['-L', 'xios/lib', '-l', 'xios/lib'])
+
+
+# # An application then only specifies which libraries it needs to link with (and
+# # in what order), and the linker then adds the correct flags during the linking
+# # stage.
+# def test_linker_add_compiler_flags_by_lib(mock_c_compiler):
+#     '''Make sure linker flags are added for the required libraries:
+#     '''
+#     linker = Linker(compiler=mock_c_compiler)
+#     linker.add_lib_flags('xios', ['-flag', '/xios/flag'])
+#     linker.add_lib_flags('netcdf', ['$(nf-config --flibs)', '($nc-config --libs)'])
+#     mock_result = mock.Mock(returncode=0)
+#     with mock.patch('fab.tools.tool.subprocess.run',
+#                     return_value=mock_result) as tool_run:
+#         linker.link([Path("a.o")], Path("a.out"), libs=['xios'], openmp=False)
+#     tool_run.assert_called_with(
+#         ['mock_c_compiler.exe', '-flag', '/xios/flag', 'a.o', '-o', 'a.out'],
+#         capture_output=True, env=None, cwd=None, check=False)
+
+

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -216,7 +216,7 @@ def test_linker_c_with_libraries_and_post_flags(mock_c_compiler):
         linker.link(
             [Path("a.o")], Path("a.out"), libs=["customlib"], openmp=False)
     link_run.assert_called_with(
-        [ "a.o", "-lcustom", "-jcustom", "-extra-flag", "-o", "a.out"])
+        ["a.o", "-lcustom", "-jcustom", "-extra-flag", "-o", "a.out"])
 
 
 def test_linker_c_with_libraries_and_pre_flags(mock_c_compiler):

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -102,7 +102,7 @@ def test_linker_get_lib_flags_unknown(mock_c_compiler):
     linker = Linker(compiler=mock_c_compiler)
     with pytest.raises(RuntimeError) as err:
         linker.get_lib_flags("unknown")
-    assert "Unknown library name" in str(err.value)
+    assert "Unknown library name: 'unknown'" in str(err.value)
 
 
 def test_linker_add_lib_flags(mock_c_compiler):
@@ -138,7 +138,7 @@ def test_linker_remove_lib_flags(mock_c_compiler):
 
     with pytest.raises(RuntimeError) as err:
         linker.get_lib_flags("netcdf")
-    assert "Unknown library name" in str(err.value)
+    assert "Unknown library name: 'netcdf'" in str(err.value)
 
 
 def test_linker_remove_lib_flags_unknown(mock_c_compiler):
@@ -170,8 +170,7 @@ def test_linker_c_with_libraries(mock_c_compiler):
     link_run.assert_called_with(
         ["-fopenmp", "a.o",
          "$(nf-config --flibs)", "($nc-config --libs)",
-         "-o", "a.out"]
-    )
+         "-o", "a.out"])
 
 
 def test_linker_c_with_custom_libraries(mock_c_compiler):
@@ -186,8 +185,21 @@ def test_linker_c_with_custom_libraries(mock_c_compiler):
         ["-fopenmp", "a.o",
          "-q", "/tmp", "-j",
          "$(nf-config --flibs)", "($nc-config --libs)",
-         "-o", "a.out"]
-    )
+         "-o", "a.out"])
+
+
+def test_linker_c_with_unknown_library(mock_c_compiler):
+    """Test the link command raises an error when unknow libraries are
+    specified.
+    """
+    linker = Linker(compiler=mock_c_compiler)\
+
+    with pytest.raises(RuntimeError) as err:
+        # Try to use "customlib" when we haven't added it to the linker
+        linker.link([Path("a.o")], Path("a.out"),
+                    libs=["netcdf", "customlib"], openmp=True)
+
+    assert "Unknown library name: 'customlib'" in str(err.value)
 
 
 def test_compiler_linker_add_compiler_flag(mock_c_compiler):

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -212,13 +212,11 @@ def test_linker_c_with_libraries_and_post_flags(mock_c_compiler):
     specified."""
     linker = Linker(compiler=mock_c_compiler)
     linker.add_lib_flags("customlib", ["-q", "/tmp", "-j"])
+    linker.add_post_lib_flags(["-extra-flag"])
 
     with mock.patch.object(linker, "run") as link_run:
         linker.link(
-            [Path("a.o")], Path("a.out"),
-            libs=["customlib"], post_lib_flags=["-extra-flag"],
-            openmp=False,
-        )
+            [Path("a.o")], Path("a.out"), libs=["customlib"], openmp=False)
     link_run.assert_called_with([
         "a.o",
         "-q", "/tmp", "-j", "-extra-flag",
@@ -231,13 +229,11 @@ def test_linker_c_with_libraries_and_pre_flags(mock_c_compiler):
     specified."""
     linker = Linker(compiler=mock_c_compiler)
     linker.add_lib_flags("customlib", ["-q", "/tmp", "-j"])
+    linker.add_pre_lib_flags(["-extra-flag"])
 
     with mock.patch.object(linker, "run") as link_run:
         linker.link(
-            [Path("a.o")], Path("a.out"),
-            pre_lib_flags=["-extra-flag"], libs=["customlib"],
-            openmp=False,
-        )
+            [Path("a.o")], Path("a.out"), libs=["customlib"], openmp=False)
     link_run.assert_called_with([
         "a.o",
         "-extra-flag", "-q", "/tmp", "-j",
@@ -299,17 +295,17 @@ def test_linker_all_flag_types(mock_c_compiler):
 
     mock_c_compiler.flags.extend(["-compiler-flag1", "-compiler-flag2"])
     linker.flags.extend(["-linker-flag1", "-linker-flag2"])
+    linker.add_pre_lib_flags(["-prelibflag1", "-prelibflag2"])
     linker.add_lib_flags("customlib1", ["-lib1flag1", "lib1flag2"])
     linker.add_lib_flags("customlib2", ["-lib2flag1", "lib2flag2"])
+    linker.add_post_lib_flags(["-postlibflag1", "-postlibflag2"])
 
     mock_result = mock.Mock(returncode=0)
     with mock.patch("fab.tools.tool.subprocess.run",
                     return_value=mock_result) as tool_run:
         linker.link([
             Path("a.o")], Path("a.out"),
-            pre_lib_flags=["-prelibflag1", "-prelibflag2"],
             libs=["customlib2", "customlib1"],
-            post_lib_flags=["-postlibflag1", "-postlibflag2"],
             openmp=True)
 
     tool_run.assert_called_with([


### PR DESCRIPTION
Add support for libraries in the `Linker` class. As per issue #7:

> In order to better support different paths on different sites:
> 
> - [ ] The linker base class should provide a dictionary that maps strings (which are 'standard' library names) to a list of linker flags. E.g.
>     ```
>     'xios' -> ["-L", "/bla/bla", "-l", "morebla"] 
>     'netcdf' -> ['$(nf-config --flibs)', '($nc-config --libs)`]`,
> - [ ] An application than only specifies which libraries it needs to link with (and in what order), and the linker then adds the correct flags during the linking stage.
> - [ ] If a library is specified that is unknown, raise an error.
> - [ ] There must be function to add and remove libraries (and Fab as default would likely provide none? Or Maybe just say netcdf as an example, since this is reasonable portable). Site-specific scripts will want to modify the settings (e.g. 