### PR TITLE
Linker as compiler wrapper (#20)

### DIFF
--- a/source/fab/tools/compiler.py
+++ b/source/fab/tools/compiler.py
@@ -59,7 +59,7 @@ class Compiler(CompilerSuiteTool):
         self._compile_flag = compile_flag if compile_flag else "-c"
         self._output_flag = output_flag if output_flag else "-o"
         self._openmp_flag = openmp_flag if openmp_flag else ""
-        self.flags.extend(os.getenv("FFLAGS", "").split())
+        self.add_flags(os.getenv("FFLAGS", "").split())
 
     @property
     def mpi(self) -> bool:

--- a/source/fab/tools/compiler_wrapper.py
+++ b/source/fab/tools/compiler_wrapper.py
@@ -25,16 +25,19 @@ class CompilerWrapper(Compiler):
     :param name: name of the wrapper.
     :param exec_name: name of the executable to call.
     :param compiler: the compiler that is decorated.
+    :param category: the tool's category. Defaults to the compiler's category.
     :param mpi: whether MPI is supported by this compiler or not.
     '''
 
     def __init__(self, name: str, exec_name: str,
                  compiler: Compiler,
+                 category: Optional[Category] = None,
                  mpi: bool = False):
         self._compiler = compiler
+        category = category or self._compiler.category
         super().__init__(
             name=name, exec_name=exec_name,
-            category=self._compiler.category,
+            category=category,
             suite=self._compiler.suite,
             mpi=mpi,
             availability_option=self._compiler.availability_option)

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -35,7 +35,7 @@ class Linker(CompilerWrapper):
             category=Category.LINKER,
             mpi=compiler.mpi)
 
-        self._flags.extend(os.getenv("LDFLAGS", "").split())
+        self.add_flags(os.getenv("LDFLAGS", "").split())
 
         # Maintain a set of flags for common libraries.
         self._lib_flags: Dict[str, List[str]] = {}

--- a/source/fab/tools/linker.py
+++ b/source/fab/tools/linker.py
@@ -9,69 +9,39 @@
 
 import os
 from pathlib import Path
-from typing import cast, Dict, List, Optional
+from typing import Dict, List, Optional, Union
 import warnings
 
 from fab.tools.category import Category
 from fab.tools.compiler import Compiler
-from fab.tools.tool import CompilerSuiteTool
+from fab.tools.compiler_wrapper import CompilerWrapper
 
 
-class Linker(CompilerSuiteTool):
+class Linker(CompilerWrapper):
     '''This is the base class for any Linker. If a compiler is specified,
     its name, executable, and compile suite will be used for the linker (if
     not explicitly set in the constructor).
 
-    :param name: the name of the linker.
-    :param exec_name: the name of the executable.
-    :param suite: optional, the name of the suite.
     :param compiler: optional, a compiler instance
     :param output_flag: flag to use to specify the output name.
     '''
 
-    # pylint: disable=too-many-arguments
-    def __init__(self, name: Optional[str] = None,
-                 exec_name: Optional[str] = None,
-                 suite: Optional[str] = None,
-                 compiler: Optional[Compiler] = None,
-                 output_flag: str = "-o"):
-        if (not name or not exec_name or not suite) and not compiler:
-            raise RuntimeError("Either specify name, exec name, and suite "
-                               "or a compiler when creating Linker.")
-        # Make mypy happy, since it can't work out otherwise if these string
-        # variables might still be None :(
-        compiler = cast(Compiler, compiler)
-        if not name:
-            name = compiler.name
-        if not exec_name:
-            exec_name = compiler.exec_name
-        if not suite:
-            suite = compiler.suite
+    def __init__(self, compiler: Compiler, output_flag: str = "-o"):
         self._output_flag = output_flag
-        super().__init__(name, exec_name, suite, Category.LINKER)
-        self._compiler = compiler
-        self.flags.extend(os.getenv("LDFLAGS", "").split())
+        super().__init__(
+            name=f"linker-{compiler.name}",
+            exec_name=compiler.exec_name,
+            compiler=compiler,
+            category=Category.LINKER,
+            mpi=compiler.mpi)
+
+        self._flags.extend(os.getenv("LDFLAGS", "").split())
 
         # Maintain a set of flags for common libraries.
         self._lib_flags: Dict[str, List[str]] = {}
         # Allow flags to include before or after any library-specific flags.
         self._pre_lib_flags: List[str] = []
         self._post_lib_flags: List[str] = []
-
-    @property
-    def mpi(self) -> bool:
-        ''':returns: whether the linker supports MPI or not.'''
-        return self._compiler.mpi
-
-    def check_available(self) -> bool:
-        '''
-        :returns: whether the linker is available or not. We do this
-            by requesting the linker version.
-        '''
-        if self._compiler:
-            return self._compiler.check_available()
-
-        return super().check_available()
 
     def get_lib_flags(self, lib: str) -> List[str]:
         '''Gets the standard flags for a standard library
@@ -141,13 +111,11 @@ class Linker(CompilerSuiteTool):
 
         :returns: the stdout of the link command
         '''
-        if self._compiler:
-            # Create a copy:
-            params = self._compiler.flags[:]
-            if openmp:
-                params.append(self._compiler.openmp_flag)
-        else:
-            params = []
+        # Don't need to add compiler's flags, they are added by CompilerWrapper.
+        params: List[Union[str, Path]] = []
+        if openmp:
+            params.append(self._compiler.openmp_flag)
+
         # TODO: why are the .o files sorted? That shouldn't matter
         params.extend(sorted(map(str, input_files)))
 

--- a/source/fab/tools/preprocessor.py
+++ b/source/fab/tools/preprocessor.py
@@ -63,7 +63,7 @@ class CppFortran(Preprocessor):
     '''
     def __init__(self):
         super().__init__("cpp", "cpp", Category.FORTRAN_PREPROCESSOR)
-        self.flags.extend(["-traditional-cpp", "-P"])
+        self.add_flags(["-traditional-cpp", "-P"])
 
 
 # ============================================================================

--- a/source/fab/tools/tool_repository.py
+++ b/source/fab/tools/tool_repository.py
@@ -93,7 +93,7 @@ class ToolRepository(dict):
         # If we have a compiler, add the compiler as linker as well
         if tool.is_compiler:
             tool = cast(Compiler, tool)
-            linker = Linker(name=f"linker-{tool.name}", compiler=tool)
+            linker = Linker(compiler=tool)
             self[linker.category].append(linker)
 
     def get_tool(self, category: Category, name: str) -> Tool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 import pytest
 
-from fab.tools import Category, CCompiler, FortranCompiler, Linker, ToolBox
+from fab.tools import CCompiler, FortranCompiler, Linker, ToolBox
 
 
 # This avoids pylint warnings about Redefining names from outer scope

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,10 +42,9 @@ def fixture_mock_fortran_compiler():
 
 
 @pytest.fixture(name="mock_linker")
-def fixture_mock_linker():
+def fixture_mock_linker(mock_fortran_compiler):
     '''Provides a mock linker.'''
-    mock_linker = Linker("mock_linker", "mock_linker.exe",
-                         Category.FORTRAN_COMPILER)
+    mock_linker = Linker(mock_fortran_compiler)
     mock_linker.run = mock.Mock()
     mock_linker._version = (1, 2, 3)
     mock_linker.add_lib_flags("netcdf", ["-lnetcdff", "-lnetcdf"])

--- a/tests/unit_tests/steps/test_link.py
+++ b/tests/unit_tests/steps/test_link.py
@@ -15,7 +15,7 @@ import pytest
 
 
 class TestLinkExe:
-    def test_run(self, tool_box):
+    def test_run(self, tool_box, mock_fortran_compiler):
         # ensure the command is formed correctly, with the flags at the
         # end (why?!)
 
@@ -29,9 +29,9 @@ class TestLinkExe:
         config.artefact_store[ArtefactSet.OBJECT_FILES] = \
             {'foo': {'foo.o', 'bar.o'}}
 
-        with mock.patch('os.getenv', return_value='-L/foo1/lib -L/foo2/lib'):
+        with mock.patch.dict("os.environ", {"FFLAGS": "-L/foo1/lib -L/foo2/lib"}):
             # We need to create a linker here to pick up the env var:
-            linker = Linker("mock_link", "mock_link.exe", "mock-vendor")
+            linker = Linker(mock_fortran_compiler)
             # Mark the linker as available to it can be added to the tool box
             linker._is_available = True
 
@@ -47,7 +47,8 @@ class TestLinkExe:
                 link_exe(config, libs=['mylib'], flags=['-fooflag', '-barflag'])
 
         tool_run.assert_called_with(
-            ['mock_link.exe', '-L/foo1/lib', '-L/foo2/lib', 'bar.o', 'foo.o',
+            ['mock_fortran_compiler.exe', '-L/foo1/lib', '-L/foo2/lib',
+             'bar.o', 'foo.o',
              '-L/my/lib', '-mylib', '-fooflag', '-barflag',
              '-o', 'workspace/foo'],
             capture_output=True, env=None, cwd=None, check=False)

--- a/tests/unit_tests/tools/test_linker.py
+++ b/tests/unit_tests/tools/test_linker.py
@@ -19,31 +19,24 @@ from fab.tools import (Category, Linker)
 def test_linker(mock_c_compiler, mock_fortran_compiler):
     '''Test the linker constructor.'''
 
-    linker = Linker(name="my_linker", exec_name="my_linker.exe", suite="suite")
+    assert mock_c_compiler.category == Category.C_COMPILER
+    assert mock_c_compiler.name == "mock_c_compiler"
+
+    linker = Linker(mock_c_compiler)
     assert linker.category == Category.LINKER
-    assert linker.name == "my_linker"
-    assert linker.exec_name == "my_linker.exe"
+    assert linker.name == "linker-mock_c_compiler"
+    assert linker.exec_name == "mock_c_compiler.exe"
     assert linker.suite == "suite"
     assert linker.flags == []
 
-    linker = Linker(name="my_linker", compiler=mock_c_compiler)
-    assert linker.category == Category.LINKER
-    assert linker.name == "my_linker"
-    assert linker.exec_name == mock_c_compiler.exec_name
-    assert linker.suite == mock_c_compiler.suite
-    assert linker.flags == []
+    assert mock_fortran_compiler.category == Category.FORTRAN_COMPILER
+    assert mock_fortran_compiler.name == "mock_fortran_compiler"
 
-    linker = Linker(compiler=mock_c_compiler)
+    linker = Linker(mock_fortran_compiler)
     assert linker.category == Category.LINKER
-    assert linker.name == mock_c_compiler.name
-    assert linker.exec_name == mock_c_compiler.exec_name
-    assert linker.suite == mock_c_compiler.suite
-    assert linker.flags == []
-
-    linker = Linker(compiler=mock_fortran_compiler)
-    assert linker.category == Category.LINKER
-    assert linker.name == mock_fortran_compiler.name
-    assert linker.exec_name == mock_fortran_compiler.exec_name
+    assert linker.name == "linker-mock_fortran_compiler"
+    assert linker.exec_name == "mock_fortran_compiler.exe"
+    assert linker.suite == "suite"
     assert linker.flags == []
 
     with pytest.raises(RuntimeError) as err:
@@ -64,29 +57,19 @@ def test_linker_check_available(mock_c_compiler):
 
     # First test if a compiler is given. The linker will call the
     # corresponding function in the compiler:
-    linker = Linker(compiler=mock_c_compiler)
-    with mock.patch.object(mock_c_compiler, "check_available",
-                           return_value=True) as comp_run:
+    linker = Linker(mock_c_compiler)
+    with mock.patch('fab.tools.compiler.Compiler.get_version',
+                    return_value=(1, 2, 3)):
         assert linker.check_available()
-    # It should be called once without any parameter
-    comp_run.assert_called_once_with()
 
-    # Second test, no compiler is given. Mock Tool.run to
-    # return a success:
-    linker = Linker("ld", "ld", suite="gnu")
-    mock_result = mock.Mock(returncode=0)
-    with mock.patch('fab.tools.tool.subprocess.run',
-                    return_value=mock_result) as tool_run:
-        linker.check_available()
-    tool_run.assert_called_once_with(
-        ["ld", "--version"], capture_output=True, env=None,
-        cwd=None, check=False)
 
-    # Third test: assume the tool does not exist, check_available
-    # will return False (and not raise  an exception)
-    linker._is_available = None
-    with mock.patch("fab.tools.tool.Tool.run",
-                    side_effect=RuntimeError("")) as tool_run:
+def test_linker_check_unavailable(mock_c_compiler):
+    '''Tests the is_available functionality.'''
+    # assume the tool does not exist, check_available
+    # will return False (and not raise an exception)
+    linker = Linker(mock_c_compiler)
+    with mock.patch('fab.tools.compiler.Compiler.get_version',
+                    side_effect=RuntimeError("")):
         assert linker.check_available() is False
 
 


### PR DESCRIPTION
Changes `Linker` to inherit `CompilerWrapper` as in Issue #20